### PR TITLE
refactor: adjust docs page layout width breakpoints

### DIFF
--- a/packages/fontpicker/src/components/App.module.css
+++ b/packages/fontpicker/src/components/App.module.css
@@ -1,21 +1,20 @@
 #app {
+  /* for auto left margin to work, TOC width should be smaller than (breakpoint - max-width)/2 */
   margin: 1em auto 160px auto;
-  max-width: 600px;
+  max-width: 800px;
   text-align: left;
   padding: 1em 0.5em;
 }
-
 * {
   vertical-align: baseline;
   box-sizing: border-box;
 }
-
 #toc {
   box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.3);
   position: fixed;
   width: 220px;
   top: 40px;
-  left: calc(50% - 550px);
+  left: calc(50% - 640px); /* half of 1280px breakpoint */
   padding: 1em 0;
 }
 #toc li {
@@ -33,8 +32,9 @@
   padding: 0;
   list-style: none;
 }
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 1280px) {
   #app {
+    margin-top: 0px;
     margin-left: 230px;
     max-width: none;
   }
@@ -45,7 +45,7 @@
     transform: none;
   }
 }
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 800px) {
   #app {
     margin-left: auto;
   }
@@ -97,16 +97,13 @@ a:hover {
   text-decoration: underline;
   color: #535bf2;
 }
-
 h3 {
   margin-top: 50px;
   border-bottom: 3px solid #123456;
 }
-
 li {
   margin: 1em 0;
 }
-
 .example {
   text-align: center;
   position: relative;
@@ -194,7 +191,6 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
 @media (prefers-color-scheme: light) {
   a:hover {
     color: #747bff;

--- a/packages/fontpicker/src/index.css
+++ b/packages/fontpicker/src/index.css
@@ -1,5 +1,4 @@
 :root {
-  /* font-family: "Comic Sans MS", system-ui; */
   font-family: system-ui;
   line-height: 1.6em;
 


### PR DESCRIPTION
Increases widths for showing tablet and desktop layouts. TOC was eating almost half the page size on some smaller widths.

Also increases page width on desktop. Desktop view was showing significantly less horizontal content than tablet mode, and requiring scrolling just to see the default usage example's code.