### PR TITLE
feat: add inputId prop

### DIFF
--- a/packages/fontpicker/src/components/App.tsx
+++ b/packages/fontpicker/src/components/App.tsx
@@ -61,6 +61,9 @@ export default function App() {
             <li>
               <a href="#manuallyadd">Manually add fonts</a>
             </li>
+            <li>
+              <a href="#forms">Forms</a>
+            </li>
           </ul>
         </div>
         <h3 id="default">Default behaviour</h3>
@@ -493,6 +496,34 @@ Font variants:
     {manuallyAddFontValue}
   </span>
 </p>
+`}
+        </pre>
+        <h3 id="forms">Forms</h3>
+        <p>
+          You can set the id of the font picker&rsquo;s input via the <code>inputId</code> prop,
+          for pairing with a <code>{`<label>`}</code>.
+        </p>
+        <form name="fontForm">
+          <label htmlFor="font">
+            Font
+          </label>
+          <div className={cs.example}>
+            <FontPicker
+              inputId="font"
+              defaultValue="Special Elite"
+              data-testid="forms-fontpicker"
+            />
+          </div>
+        </form>
+        <pre>{`<form name="fontForm">
+  <label htmlFor="font">
+    Font
+  </label>
+  <FontPicker
+    inputId="font"
+    defaultValue="Special Elite"
+  />
+</form>
 `}
         </pre>
       </div>

--- a/packages/fontpicker/src/components/FontPicker.tsx
+++ b/packages/fontpicker/src/components/FontPicker.tsx
@@ -14,6 +14,9 @@ export interface FontPickerProps extends React.ComponentPropsWithoutRef<'div'> {
   fontCategories?: string[] | string
   localFonts?: Font[] | undefined
 
+  // For pairing with form labels
+  inputId?: string
+
   // Callbacks to emit selected font
   fontVariants?: (fontVariants: FontToVariant) => void
   value?: (value: string) => void
@@ -90,6 +93,7 @@ export default function FontPicker({
   fontVariants,
   value,
   loading = <div>Font previews loading ...</div>,
+  inputId,
   ...rest
 }: FontPickerProps) {
   const [focused, setFocused] = useState(false)
@@ -537,6 +541,7 @@ export default function FontPicker({
             <FontPreviews />
             <div ref={previewRef} className={previewClasses()?.join(' ')} />
             <input
+              id={inputId}
               className={'fontpicker__search'}
               ref={inputRef}
               type="text"


### PR DESCRIPTION
Adds inputId prop to FontPicker. This allows setting the font picker's input's id, for use in pairing with form labels.