### PR TITLE
Fix font preview generation in CI

### DIFF
--- a/packages/fontpicker/scripts/buildFontPreviews.ts
+++ b/packages/fontpicker/scripts/buildFontPreviews.ts
@@ -157,8 +157,8 @@ class GoogleFonts {
       }
     }
     const localJsonFile = this.fontPath + '/fonts.json'
-    const modifiedTime = fs.statSync(localJsonFile).mtime
-    const age = Math.abs(new Date().getTime() - modifiedTime.getTime())
+    const modifiedTime = fs.statSync(localJsonFile, { throwIfNoEntry: false })?.mtime
+    const age = Math.abs(new Date().getTime() - (modifiedTime?.getTime() ?? 0))
     const oneWeekMillis = 1000 * 60 * 60 * 24 * 7
     if (!fs.existsSync(localJsonFile) || (!noReplaceOldFontInfos && age > oneWeekMillis)) {
       println('Font cache info file missing or out of date, downloading ...')


### PR DESCRIPTION
Fixes error in font preview generation code that checks existence of and age of existing font cache fonts.json info file. The error only occurs if previews haven't been generated before, i.e. in a new environment like CI.