### PR TITLE
66 Local fonts with autoLoad

### DIFF
--- a/packages/fontpicker/src/components/App.tsx
+++ b/packages/fontpicker/src/components/App.tsx
@@ -447,6 +447,7 @@ Font variants:
         </p>
         <div className={cs.example}>
           <FontPicker
+            autoLoad
             value={(font: string) => setManuallyAddFontValue(font)}
             googleFonts={['Tinos', 'Open Sans']}
             localFonts={[

--- a/packages/fontpicker/src/components/FontPicker.tsx
+++ b/packages/fontpicker/src/components/FontPicker.tsx
@@ -36,6 +36,7 @@ export interface Font {
   sane: string
   cased: string
   variants: Variant[]
+  isLocal?: boolean
 }
 
 export interface FourFonts {
@@ -240,6 +241,7 @@ export default function FontPicker({
           .replaceAll(/[^a-zA-Z0-9-]/g, '')
           .toLowerCase(),
         variants: font.variants.map((v: Variant) => toString(v)),
+        isLocal: true,
       })
     })
     let activeFontsInCategory: Font[]
@@ -450,6 +452,10 @@ export default function FontPicker({
 
   const loadFontFromObject = useCallback(
     (font: Font, variants: Variant[] = []) => {
+      if (font?.isLocal) {
+        // Don't try to load manually added fonts
+        return
+      }
       if (variants?.length > 0) {
         variants = font.variants.filter((v: Variant) => variants.includes(v))
       } else if (loadAllVariants) {


### PR DESCRIPTION
Addresses #66.

Previously using `autoLoad` while manually added fonts were specified via `localFonts` resulted in bad requests to the Google Fonts API as the picker didn't differentiate between local and Google fonts. This prevents those bad requests from being created.

`autoLoad` is still not supported for manually added fonts via `localFonts`.