### PR TITLE
Support filter by language

### DIFF
--- a/packages/fontpicker/font-preview/fontInfo.json
+++ b/packages/fontpicker/font-preview/fontInfo.json
@@ -6,6 +6,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14,6 +18,9 @@
     "sane": "abel",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -26,6 +33,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala"
     ]
   },
   {
@@ -34,6 +46,10 @@
     "sane": "aboreto",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -42,6 +58,10 @@
     "sane": "abril_fatface",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -50,6 +70,11 @@
     "sane": "abyssinica_sil",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "ethiopic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -58,6 +83,10 @@
     "sane": "aclonica",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -66,6 +95,9 @@
     "sane": "acme",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -74,6 +106,9 @@
     "sane": "actor",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -82,6 +117,9 @@
     "sane": "adamina",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -90,6 +128,11 @@
     "sane": "adlam_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "adlam",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -115,6 +158,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -130,6 +180,35 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Afacad Flux",
+    "sane": "afacad_flux",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -138,6 +217,12 @@
     "sane": "agbalumo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -147,6 +232,23 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Agu Display",
+    "sane": "agu_display",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -155,6 +257,10 @@
     "sane": "aguafina_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -168,6 +274,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tifinagh"
     ]
   },
   {
@@ -176,6 +287,11 @@
     "sane": "akaya_kanadaka",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -184,6 +300,11 @@
     "sane": "akaya_telivigala",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -192,6 +313,10 @@
     "sane": "akronim",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -204,6 +329,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -212,6 +342,10 @@
     "sane": "aladin",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -220,6 +354,11 @@
     "sane": "alata",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -228,6 +367,12 @@
     "sane": "alatsi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -253,6 +398,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -261,6 +410,9 @@
     "sane": "aldrich",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -270,6 +422,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -289,6 +446,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -310,6 +476,15 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -331,6 +506,15 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -348,6 +532,15 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -373,6 +566,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -381,6 +579,11 @@
     "sane": "alex_brush",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -397,6 +600,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -405,6 +614,11 @@
     "sane": "alfa_slab_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -413,6 +627,12 @@
     "sane": "alice",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -421,6 +641,12 @@
     "sane": "alike",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -429,6 +655,12 @@
     "sane": "alike_angular",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -437,6 +669,11 @@
     "sane": "alkalami",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -448,6 +685,13 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "bengali",
+      "devanagari",
+      "latin",
+      "latin-ext",
+      "oriya"
     ]
   },
   {
@@ -457,6 +701,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -465,6 +713,9 @@
     "sane": "allerta",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -473,6 +724,9 @@
     "sane": "allerta_stencil",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -481,6 +735,11 @@
     "sane": "allison",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -489,6 +748,26 @@
     "sane": "allura",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Almarai",
+    "sane": "almarai",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "arabic",
+      "latin"
     ]
   },
   {
@@ -500,6 +779,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -508,6 +791,10 @@
     "sane": "almendra_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -516,6 +803,9 @@
     "sane": "almendra_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -541,6 +831,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -550,6 +847,12 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -559,6 +862,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -568,6 +876,13 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -576,6 +891,10 @@
     "sane": "amarante",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -587,6 +906,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -596,6 +918,13 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -604,6 +933,9 @@
     "sane": "amethysta",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -614,6 +946,11 @@
       "0,400",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -625,6 +962,11 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -633,6 +975,10 @@
     "sane": "amiri_quran",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin"
     ]
   },
   {
@@ -642,6 +988,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -649,7 +1000,16 @@
     "name": "Anaheim",
     "sane": "anaheim",
     "variants": [
-      "0,400"
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -667,6 +1027,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -678,6 +1043,13 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -693,6 +1065,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -708,6 +1085,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -723,6 +1105,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -738,6 +1125,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -753,6 +1145,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -768,6 +1165,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -783,6 +1185,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "malayalam"
     ]
   },
   {
@@ -798,6 +1205,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "oriya"
     ]
   },
   {
@@ -813,6 +1225,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -828,6 +1245,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -836,6 +1258,10 @@
     "sane": "angkor",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -845,6 +1271,13 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -853,6 +1286,10 @@
     "sane": "annie_use_your_telescope",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -864,6 +1301,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -872,6 +1315,12 @@
     "sane": "anta",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -880,6 +1329,9 @@
     "sane": "antic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -888,6 +1340,9 @@
     "sane": "antic_didone",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -896,6 +1351,9 @@
     "sane": "antic_slab",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -904,6 +1362,24 @@
     "sane": "anton",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Anton SC",
+    "sane": "anton_sc",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -918,6 +1394,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -932,6 +1412,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -957,6 +1443,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -965,6 +1456,11 @@
     "sane": "aoboshi_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -976,6 +1472,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -985,6 +1486,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -993,6 +1497,10 @@
     "sane": "arbutus",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1001,6 +1509,10 @@
     "sane": "arbutus_slab",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1009,6 +1521,10 @@
     "sane": "architects_daughter",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1034,6 +1550,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1042,6 +1563,10 @@
     "sane": "archivo_black",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1057,6 +1582,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1065,6 +1595,11 @@
     "sane": "are_you_serious",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1074,6 +1609,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1083,6 +1623,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1097,6 +1642,15 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "malayalam",
+      "tamil",
+      "vietnamese"
     ]
   },
   {
@@ -1112,6 +1666,16 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1120,6 +1684,11 @@
     "sane": "arizonia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1128,6 +1697,10 @@
     "sane": "armata",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1139,6 +1712,31 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Arsenal SC",
+    "sane": "arsenal_sc",
+    "variants": [
+      "0,400",
+      "1,400",
+      "0,700",
+      "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1147,6 +1745,9 @@
     "sane": "artifika",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1158,6 +1759,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1167,6 +1771,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1192,6 +1801,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1215,6 +1829,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1223,6 +1842,11 @@
     "sane": "asar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1231,6 +1855,13 @@
     "sane": "asset",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -1245,6 +1876,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1254,6 +1890,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1263,6 +1902,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1276,6 +1918,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -1287,6 +1935,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1299,6 +1951,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1307,6 +1964,10 @@
     "sane": "atomic_age",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1315,6 +1976,9 @@
     "sane": "aubrey",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1323,6 +1987,10 @@
     "sane": "audiowide",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1331,6 +1999,10 @@
     "sane": "autour_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1339,6 +2011,10 @@
     "sane": "average",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1347,6 +2023,10 @@
     "sane": "average_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1355,6 +2035,10 @@
     "sane": "averia_gruesa_libre",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1368,6 +2052,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1381,6 +2068,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1394,6 +2084,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1419,6 +2112,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1430,6 +2127,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1441,6 +2141,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1449,6 +2152,11 @@
     "sane": "babylonica",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1457,6 +2165,10 @@
     "sane": "bacasime_antique",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1465,6 +2177,26 @@
     "sane": "bad_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Badeen Display",
+    "sane": "badeen_display",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1473,6 +2205,11 @@
     "sane": "bagel_fat_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1481,6 +2218,10 @@
     "sane": "bahiana",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1489,6 +2230,11 @@
     "sane": "bahianita",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1508,6 +2254,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -1516,6 +2268,11 @@
     "sane": "bakbak_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1524,6 +2281,11 @@
     "sane": "ballet",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1536,6 +2298,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1548,6 +2316,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1560,6 +2334,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1572,6 +2352,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "oriya",
+      "vietnamese"
     ]
   },
   {
@@ -1584,6 +2370,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "malayalam",
+      "vietnamese"
     ]
   },
   {
@@ -1596,6 +2388,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1608,6 +2406,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1620,6 +2424,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1632,6 +2442,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu",
+      "vietnamese"
     ]
   },
   {
@@ -1644,6 +2460,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil",
+      "vietnamese"
     ]
   },
   {
@@ -1655,6 +2477,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1663,6 +2491,9 @@
     "sane": "balthazar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1671,6 +2502,11 @@
     "sane": "bangers",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1696,6 +2532,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1721,6 +2562,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1746,6 +2592,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1754,6 +2605,11 @@
     "sane": "barriecito",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1762,6 +2618,10 @@
     "sane": "barrio",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1770,6 +2630,10 @@
     "sane": "basic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1779,6 +2643,22 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "serif",
+    "name": "Baskervville SC",
+    "sane": "baskervville_sc",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1791,6 +2671,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -1799,6 +2683,9 @@
     "sane": "baumans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1807,6 +2694,10 @@
     "sane": "bayon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -1832,6 +2723,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1840,6 +2736,11 @@
     "sane": "beau_rivage",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1848,6 +2749,31 @@
     "sane": "bebas_neue",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Beiruti",
+    "sane": "beiruti",
+    "variants": [
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1858,6 +2784,10 @@
       "0,400",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1866,6 +2796,9 @@
     "sane": "belgrano",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1874,6 +2807,11 @@
     "sane": "bellefair",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1882,6 +2820,10 @@
     "sane": "belleza",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1895,6 +2837,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1908,6 +2856,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1918,6 +2872,10 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1926,6 +2884,11 @@
     "sane": "benne",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1934,6 +2897,10 @@
     "sane": "bentham",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1942,6 +2909,10 @@
     "sane": "berkshire_swash",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1961,6 +2932,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -1969,6 +2944,9 @@
     "sane": "beth_ellen",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -1978,6 +2956,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -1986,6 +2969,11 @@
     "sane": "bhutuka_expanded_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2002,6 +2990,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2018,6 +3011,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2034,6 +3032,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2050,6 +3053,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2066,6 +3074,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2082,6 +3095,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2090,6 +3108,10 @@
     "sane": "bigelow_rules",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2098,6 +3120,9 @@
     "sane": "bigshot_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2106,6 +3131,11 @@
     "sane": "bilbo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2114,6 +3144,10 @@
     "sane": "bilbo_swash_caps",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2128,6 +3162,10 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2140,6 +3178,10 @@
       "0,400",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2148,6 +3190,11 @@
     "sane": "birthstone",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2157,6 +3204,11 @@
     "variants": [
       "0,400",
       "0,500"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2171,6 +3223,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2196,6 +3253,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2205,6 +3269,13 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek-ext",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2214,6 +3285,13 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek-ext",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2223,6 +3301,13 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek-ext",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2232,6 +3317,13 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek-ext",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2240,6 +3332,10 @@
     "sane": "black_and_white_picture",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -2248,6 +3344,10 @@
     "sane": "black_han_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -2256,6 +3356,12 @@
     "sane": "black_ops_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2264,6 +3370,11 @@
     "sane": "blaka",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2272,6 +3383,11 @@
     "sane": "blaka_hollow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2280,6 +3396,11 @@
     "sane": "blaka_ink",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2295,6 +3416,10 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2314,6 +3439,37 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
+    ]
+  },
+  {
+    "category": "serif",
+    "name": "Bodoni Moda SC",
+    "sane": "bodoni_moda_sc",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -2322,6 +3478,10 @@
     "sane": "bokor",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -2332,6 +3492,34 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "serif",
+    "name": "Bona Nova SC",
+    "sane": "bona_nova_sc",
+    "variants": [
+      "0,400",
+      "1,400",
+      "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2340,6 +3528,9 @@
     "sane": "bonbon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2348,6 +3539,11 @@
     "sane": "bonheur_royale",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2356,6 +3552,9 @@
     "sane": "boogaloo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2364,6 +3563,13 @@
     "sane": "borel",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -2372,6 +3578,9 @@
     "sane": "bowlby_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2380,6 +3589,10 @@
     "sane": "bowlby_one_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2388,6 +3601,12 @@
     "sane": "braah_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2397,6 +3616,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2405,6 +3627,10 @@
     "sane": "bree_serif",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2419,6 +3645,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2427,6 +3658,10 @@
     "sane": "bruno_ace",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2435,6 +3670,10 @@
     "sane": "bruno_ace_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2450,6 +3689,14 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2458,6 +3705,10 @@
     "sane": "bubblegum_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2466,6 +3717,10 @@
     "sane": "bubbler_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2474,6 +3729,9 @@
     "sane": "buda",
     "variants": [
       "0,300"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2483,6 +3741,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2491,6 +3753,11 @@
     "sane": "bungee",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2499,6 +3766,11 @@
     "sane": "bungee_hairline",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2507,6 +3779,11 @@
     "sane": "bungee_inline",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2515,6 +3792,11 @@
     "sane": "bungee_outline",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2523,6 +3805,11 @@
     "sane": "bungee_shade",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2531,6 +3818,24 @@
     "sane": "bungee_spice",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Bungee Tint",
+    "sane": "bungee_tint",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2539,6 +3844,10 @@
     "sane": "butcherman",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2547,6 +3856,10 @@
     "sane": "butterfly_kids",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2562,6 +3875,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2573,6 +3891,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2582,6 +3905,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2590,6 +3916,13 @@
     "sane": "cactus_classical_serif",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-hongkong",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2598,6 +3931,9 @@
     "sane": "caesar_dressing",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2606,6 +3942,9 @@
     "sane": "cagliostro",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2621,6 +3960,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2636,6 +3980,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2647,6 +3996,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2655,6 +4008,11 @@
     "sane": "calistoga",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2663,6 +4021,9 @@
     "sane": "calligraffitti",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2674,6 +4035,11 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2682,6 +4048,10 @@
     "sane": "cambo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2690,6 +4060,9 @@
     "sane": "candal",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2701,6 +4074,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2709,6 +4086,10 @@
     "sane": "cantata_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2717,6 +4098,10 @@
     "sane": "cantora_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2725,6 +4110,10 @@
     "sane": "caprasimo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2733,6 +4122,10 @@
     "sane": "capriola",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2741,6 +4134,11 @@
     "sane": "caramel",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2749,6 +4147,11 @@
     "sane": "carattere",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2759,6 +4162,12 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2770,6 +4179,15 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2778,6 +4196,9 @@
     "sane": "carme",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2786,6 +4207,9 @@
     "sane": "carrois_gothic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2794,6 +4218,9 @@
     "sane": "carrois_gothic_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2802,6 +4229,9 @@
     "sane": "carter_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2811,6 +4241,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2819,6 +4253,10 @@
     "sane": "castoro_titling",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2835,6 +4273,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -2846,6 +4289,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2857,6 +4306,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2865,6 +4320,10 @@
     "sane": "caveat_brush",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2873,6 +4332,9 @@
     "sane": "cedarville_cursive",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2881,6 +4343,10 @@
     "sane": "ceviche_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2898,6 +4364,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -2912,6 +4384,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2921,6 +4398,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -2929,6 +4409,10 @@
     "sane": "chango",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2940,6 +4424,13 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -2949,6 +4440,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -2958,6 +4455,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -2970,6 +4473,10 @@
       "0,400",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -2979,6 +4486,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2987,6 +4498,10 @@
     "sane": "chela_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -2995,6 +4510,10 @@
     "sane": "chelsea_market",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3003,6 +4522,11 @@
     "sane": "cherish",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3011,6 +4535,12 @@
     "sane": "cherry_bomb_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3019,6 +4549,9 @@
     "sane": "cherry_cream_soda",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3028,6 +4561,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3036,6 +4573,9 @@
     "sane": "chewy",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3044,6 +4584,10 @@
     "sane": "chicle",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3052,6 +4596,11 @@
     "sane": "chilanka",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "malayalam"
     ]
   },
   {
@@ -3077,6 +4626,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3102,6 +4656,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3110,6 +4669,13 @@
     "sane": "chocolate_classical_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-hongkong",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3118,6 +4684,12 @@
     "sane": "chokokutai",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3126,6 +4698,12 @@
     "sane": "chonburi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -3139,6 +4717,10 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3149,6 +4731,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3157,6 +4743,10 @@
     "sane": "clicker_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3165,6 +4755,10 @@
     "sane": "climate_crisis",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3174,6 +4768,10 @@
     "variants": [
       "0,400",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3183,6 +4781,10 @@
     "variants": [
       "0,300",
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3191,6 +4793,12 @@
     "sane": "coiny",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil",
+      "vietnamese"
     ]
   },
   {
@@ -3199,6 +4807,10 @@
     "sane": "combo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3211,6 +4823,14 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3219,6 +4839,12 @@
     "sane": "comforter",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3227,6 +4853,12 @@
     "sane": "comforter_brush",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3240,6 +4872,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3248,6 +4883,9 @@
     "sane": "coming_soon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3264,6 +4902,10 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3280,6 +4922,14 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3288,6 +4938,10 @@
     "sane": "concert_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3296,6 +4950,10 @@
     "sane": "condiment",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3304,6 +4962,9 @@
     "sane": "contrail_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3312,6 +4973,10 @@
     "sane": "convergence",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3320,6 +4985,9 @@
     "sane": "cookie",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3328,6 +4996,9 @@
     "sane": "copse",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3337,6 +5008,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3346,6 +5021,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3363,6 +5043,13 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3380,6 +5067,13 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3397,6 +5091,13 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3409,6 +5110,13 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3421,6 +5129,13 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3433,6 +5148,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3441,6 +5161,10 @@
     "sane": "courgette",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3452,6 +5176,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3463,6 +5191,16 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3472,6 +5210,9 @@
     "variants": [
       "0,400",
       "0,900"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3480,6 +5221,10 @@
     "sane": "covered_by_your_grace",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3488,6 +5233,9 @@
     "sane": "crafty_girls",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3496,6 +5244,9 @@
     "sane": "creepster",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3505,6 +5256,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3528,6 +5283,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3541,6 +5301,11 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3549,6 +5314,10 @@
     "sane": "croissant_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3557,6 +5326,10 @@
     "sane": "crushed",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3572,6 +5345,13 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3580,6 +5360,10 @@
     "sane": "cute_font",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -3588,6 +5372,10 @@
     "sane": "cutive",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3596,6 +5384,10 @@
     "sane": "cutive_mono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3613,6 +5405,11 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "new-tai-lue"
     ]
   },
   {
@@ -3621,6 +5418,10 @@
     "sane": "damion",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3632,6 +5433,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3640,6 +5446,11 @@
     "sane": "danfo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3648,6 +5459,10 @@
     "sane": "dangrek",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -3662,6 +5477,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3670,6 +5490,11 @@
     "sane": "darumadrop_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3680,6 +5505,14 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -3688,6 +5521,9 @@
     "sane": "dawning_of_a_new_day",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3696,6 +5532,9 @@
     "sane": "days_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3704,6 +5543,11 @@
     "sane": "dekko",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3712,6 +5556,14 @@
     "sane": "dela_gothic_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3720,6 +5572,10 @@
     "sane": "delicious_handrawn",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3728,6 +5584,9 @@
     "sane": "delius",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3736,6 +5595,9 @@
     "sane": "delius_swash_caps",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3745,6 +5607,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3753,6 +5618,9 @@
     "sane": "della_respira",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3761,6 +5629,12 @@
     "sane": "denk_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3769,6 +5643,10 @@
     "sane": "devonshire",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3777,6 +5655,10 @@
     "sane": "dhurjati",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -3785,6 +5667,14 @@
     "sane": "didact_gothic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3793,6 +5683,11 @@
     "sane": "diphylleia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3801,6 +5696,10 @@
     "sane": "diplomata",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3809,6 +5708,10 @@
     "sane": "diplomata_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3822,6 +5725,10 @@
       "1,400",
       "0,500",
       "1,500"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3847,6 +5754,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3856,6 +5767,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3865,6 +5780,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3873,6 +5792,10 @@
     "sane": "do_hyeon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -3881,6 +5804,10 @@
     "sane": "dokdo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -3892,6 +5819,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3900,6 +5831,10 @@
     "sane": "donegal_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3910,6 +5845,12 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3918,6 +5859,10 @@
     "sane": "doppio_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3926,6 +5871,9 @@
     "sane": "dorsa",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -3940,6 +5888,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -3948,6 +5901,32 @@
     "sane": "dotgothic16",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Doto",
+    "sane": "doto",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3956,6 +5935,10 @@
     "sane": "dr_sugiyama",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3964,6 +5947,10 @@
     "sane": "duru_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3972,6 +5959,10 @@
     "sane": "dynalight",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3983,6 +5974,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3991,6 +5987,10 @@
     "sane": "eagle_lake",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -3999,6 +5999,10 @@
     "sane": "east_sea_dokdo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -4007,6 +6011,10 @@
     "sane": "eater",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4024,6 +6032,15 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4035,6 +6052,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4047,6 +6068,88 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "devanagari",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Edu AU VIC WA NT Arrows",
+    "sane": "edu_au_vic_wa_nt_arrows",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Edu AU VIC WA NT Dots",
+    "sane": "edu_au_vic_wa_nt_dots",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Edu AU VIC WA NT Guides",
+    "sane": "edu_au_vic_wa_nt_guides",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Edu AU VIC WA NT Hand",
+    "sane": "edu_au_vic_wa_nt_hand",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Edu AU VIC WA NT Pre",
+    "sane": "edu_au_vic_wa_nt_pre",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4058,6 +6161,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4069,6 +6175,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4080,6 +6189,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4091,6 +6203,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4102,6 +6217,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4113,6 +6231,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4121,6 +6245,9 @@
     "sane": "electrolize",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4130,6 +6257,10 @@
     "variants": [
       "0,400",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4139,6 +6270,10 @@
     "variants": [
       "0,400",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4147,6 +6282,10 @@
     "sane": "emblema_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4155,6 +6294,10 @@
     "sane": "emilys_candy",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4171,6 +6314,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4187,6 +6335,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4203,6 +6356,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4219,6 +6377,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4235,6 +6398,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4251,6 +6419,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4259,6 +6432,10 @@
     "sane": "engagement",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4267,6 +6444,10 @@
     "sane": "englebert",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4278,6 +6459,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4286,6 +6471,11 @@
     "sane": "ephesis",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4311,6 +6501,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4319,6 +6514,10 @@
     "sane": "erica_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4327,6 +6526,10 @@
     "sane": "esteban",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4335,6 +6538,11 @@
     "sane": "estonia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4343,6 +6551,10 @@
     "sane": "euphoria_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4351,6 +6563,10 @@
     "sane": "ewert",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4376,6 +6592,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4401,6 +6622,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4416,6 +6644,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4424,6 +6656,24 @@
     "sane": "explora",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cherokee",
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Faculty Glyphic",
+    "sane": "faculty_glyphic",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4443,6 +6693,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -4458,6 +6714,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4467,6 +6728,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4478,6 +6743,10 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4486,6 +6755,12 @@
     "sane": "farsan",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4494,6 +6769,10 @@
     "sane": "fascinate",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4502,6 +6781,10 @@
     "sane": "fascinate_inline",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4510,6 +6793,10 @@
     "sane": "faster_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4518,6 +6805,10 @@
     "sane": "fasthand",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -4526,6 +6817,10 @@
     "sane": "fauna_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4545,6 +6840,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4553,6 +6853,9 @@
     "sane": "federant",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4561,6 +6864,9 @@
     "sane": "federo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4569,6 +6875,10 @@
     "sane": "felipa",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4577,6 +6887,10 @@
     "sane": "fenix",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4585,6 +6899,11 @@
     "sane": "festive",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4606,6 +6925,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4614,6 +6937,9 @@
     "sane": "finger_paint",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4629,6 +6955,12 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4641,6 +6973,14 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4651,6 +6991,14 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4676,6 +7024,15 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4701,6 +7058,15 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4726,6 +7092,15 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4734,6 +7109,12 @@
     "sane": "fjalla_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4742,6 +7123,9 @@
     "sane": "fjord_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4751,6 +7135,9 @@
     "variants": [
       "0,300",
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4759,6 +7146,10 @@
     "sane": "flavors",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4767,6 +7158,11 @@
     "sane": "fleur_de_leah",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4775,6 +7171,13 @@
     "sane": "flow_block",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4783,6 +7186,13 @@
     "sane": "flow_circular",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4791,6 +7201,13 @@
     "sane": "flow_rounded",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4807,6 +7224,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4816,6 +7238,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4824,6 +7250,9 @@
     "sane": "fontdiner_swanky",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4832,6 +7261,12 @@
     "sane": "forum",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4841,6 +7276,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4849,6 +7289,11 @@
     "sane": "francois_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4863,6 +7308,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4888,6 +7338,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4896,6 +7351,10 @@
     "sane": "freckle_face",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4904,6 +7363,10 @@
     "sane": "fredericka_the_great",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4916,6 +7379,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4924,6 +7392,10 @@
     "sane": "freehand",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -4932,6 +7404,11 @@
     "sane": "freeman",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4940,6 +7417,10 @@
     "sane": "fresca",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4948,6 +7429,9 @@
     "sane": "frijole",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4957,6 +7441,12 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4965,6 +7455,9 @@
     "sane": "fugaz_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -4973,6 +7466,70 @@
     "sane": "fuggles",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Funnel Display",
+    "sane": "funnel_display",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Funnel Sans",
+    "sane": "funnel_sans",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Fustat",
+    "sane": "fustat",
+    "variants": [
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -4982,6 +7539,24 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Ga Maamli",
+    "sane": "ga_maamli",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -4995,6 +7570,10 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5003,6 +7582,12 @@
     "sane": "gabriela",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5013,6 +7598,10 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -5021,6 +7610,10 @@
     "sane": "gafata",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5029,6 +7622,11 @@
     "sane": "gajraj_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5037,6 +7635,10 @@
     "sane": "galada",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "bengali",
+      "latin"
     ]
   },
   {
@@ -5045,6 +7647,9 @@
     "sane": "galdeano",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5053,6 +7658,10 @@
     "sane": "galindo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5061,6 +7670,10 @@
     "sane": "gamja_flower",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -5086,6 +7699,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5094,6 +7711,11 @@
     "sane": "gasoek_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5104,6 +7726,50 @@
       "0,100",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "malayalam"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Geist",
+    "sane": "geist",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "monospace",
+    "name": "Geist Mono",
+    "sane": "geist_mono",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5119,6 +7785,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5133,6 +7804,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala"
     ]
   },
   {
@@ -5158,6 +7834,12 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cherokee",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5169,6 +7851,15 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5180,6 +7871,15 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5189,6 +7889,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5205,6 +7908,14 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5230,6 +7941,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5238,6 +7954,9 @@
     "sane": "geostar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5246,6 +7965,9 @@
     "sane": "geostar_fill",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5254,6 +7976,9 @@
     "sane": "germania_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5262,6 +7987,11 @@
     "sane": "gideon_roman",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5270,6 +8000,11 @@
     "sane": "gidugu",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -5278,6 +8013,10 @@
     "sane": "gilda_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5286,6 +8025,10 @@
     "sane": "girassol",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5294,6 +8037,10 @@
     "sane": "give_you_glory",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5302,6 +8049,10 @@
     "sane": "glass_antiqua",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5311,6 +8062,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5319,6 +8075,11 @@
     "sane": "gloock",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5327,6 +8088,10 @@
     "sane": "gloria_hallelujah",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5350,6 +8115,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5366,6 +8136,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5374,6 +8149,9 @@
     "sane": "goblin_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5382,6 +8160,9 @@
     "sane": "gochi_hand",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5391,6 +8172,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5404,6 +8190,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5413,6 +8205,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5429,6 +8224,16 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5437,6 +8242,12 @@
     "sane": "gotu",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5445,6 +8256,9 @@
     "sane": "goudy_bookletter_1911",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5454,6 +8268,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5462,6 +8282,12 @@
     "sane": "gowun_dodum",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5470,6 +8296,9 @@
     "sane": "graduate",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5478,6 +8307,10 @@
     "sane": "grand_hotel",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5486,6 +8319,11 @@
     "sane": "grandiflora_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5511,6 +8349,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5519,6 +8362,11 @@
     "sane": "grape_nuts",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5527,6 +8375,9 @@
     "sane": "gravitas_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5535,6 +8386,14 @@
     "sane": "great_vibes",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5543,6 +8402,11 @@
     "sane": "grechen_fuemen",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5568,6 +8432,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5584,6 +8453,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5592,6 +8466,11 @@
     "sane": "grey_qo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5600,6 +8479,10 @@
     "sane": "griffy",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5608,6 +8491,10 @@
     "sane": "gruppo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5618,6 +8505,10 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5626,6 +8517,10 @@
     "sane": "gugi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -5634,6 +8529,11 @@
     "sane": "gulzar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5644,6 +8544,9 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5652,6 +8555,11 @@
     "sane": "gurajada",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -5661,6 +8569,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5669,6 +8582,10 @@
     "sane": "habibi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5677,6 +8594,12 @@
     "sane": "hachi_maru_pop",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5693,6 +8616,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5705,6 +8634,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5713,6 +8647,10 @@
     "sane": "hammersmith_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5721,6 +8659,10 @@
     "sane": "hanalei",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5729,6 +8671,10 @@
     "sane": "hanalei_fill",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5745,6 +8691,17 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "armenian",
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5753,6 +8710,9 @@
     "sane": "handlee",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5778,6 +8738,12 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5790,6 +8756,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -5798,6 +8768,10 @@
     "sane": "happy_monkey",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5809,6 +8783,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5817,6 +8796,10 @@
     "sane": "headland_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5825,6 +8808,12 @@
     "sane": "hedvig_letters_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -5833,6 +8822,12 @@
     "sane": "hedvig_letters_serif",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -5849,6 +8844,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -5857,6 +8859,9 @@
     "sane": "henny_penny",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5873,6 +8878,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5881,6 +8891,10 @@
     "sane": "herr_von_muellerhoff",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5889,6 +8903,10 @@
     "sane": "hi_melody",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -5897,6 +8915,13 @@
     "sane": "hina_mincho",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -5909,6 +8934,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5921,6 +8951,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -5933,6 +8968,28 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Hind Mysuru",
+    "sane": "hind_mysuru",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5945,6 +9002,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5957,6 +9019,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5965,6 +9032,10 @@
     "sane": "holtwood_one_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5973,6 +9044,9 @@
     "sane": "homemade_apple",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5981,6 +9055,9 @@
     "sane": "homenaje",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -5989,6 +9066,36 @@
     "sane": "honk",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Host Grotesk",
+    "sane": "host_grotesk",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -5997,6 +9104,39 @@
     "sane": "hubballi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Hubot Sans",
+    "sane": "hubot_sans",
+    "variants": [
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900",
+      "1,200",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6005,6 +9145,11 @@
     "sane": "hurricane",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6020,6 +9165,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6041,6 +9190,13 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6062,6 +9218,14 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6076,6 +9240,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6097,6 +9267,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6111,6 +9287,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6125,6 +9307,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6139,6 +9327,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6153,6 +9347,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6167,6 +9366,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "thai"
     ]
   },
   {
@@ -6181,6 +9386,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "thai"
     ]
   },
   {
@@ -6202,6 +9413,13 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6210,6 +9428,9 @@
     "sane": "iceberg",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6218,6 +9439,9 @@
     "sane": "iceland",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6227,6 +9451,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6235,6 +9462,9 @@
     "sane": "im_fell_double_pica_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6244,6 +9474,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6252,6 +9485,9 @@
     "sane": "im_fell_dw_pica_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6261,6 +9497,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6269,6 +9508,9 @@
     "sane": "im_fell_english_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6278,6 +9520,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6286,6 +9531,9 @@
     "sane": "im_fell_french_canon_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6295,6 +9543,9 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6303,6 +9554,9 @@
     "sane": "im_fell_great_primer_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6319,6 +9573,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6327,6 +9586,11 @@
     "sane": "imperial_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6335,6 +9599,10 @@
     "sane": "imprima",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6344,6 +9612,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6359,6 +9632,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6367,6 +9645,10 @@
     "sane": "inder",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6375,6 +9657,10 @@
     "sane": "indie_flower",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6383,6 +9669,11 @@
     "sane": "ingrid_darling",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6392,6 +9683,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6406,6 +9701,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6419,6 +9719,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6432,6 +9736,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6440,6 +9748,11 @@
     "sane": "inspiration",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6455,6 +9768,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6464,6 +9781,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6479,7 +9800,25 @@
       "0,600",
       "0,700",
       "0,800",
-      "0,900"
+      "0,900",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6505,6 +9844,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6513,6 +9861,9 @@
     "sane": "irish_grover",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6521,6 +9872,11 @@
     "sane": "island_moments",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6532,6 +9888,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6540,6 +9902,9 @@
     "sane": "italiana",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6548,6 +9913,11 @@
     "sane": "italianno",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6556,6 +9926,12 @@
     "sane": "itim",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -6564,6 +9940,12 @@
     "sane": "jacquard_12",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -6572,6 +9954,12 @@
     "sane": "jacquard_12_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -6580,6 +9968,10 @@
     "sane": "jacquard_24",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6588,6 +9980,10 @@
     "sane": "jacquard_24_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6596,6 +9992,12 @@
     "sane": "jacquarda_bastarda_9",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -6604,6 +10006,12 @@
     "sane": "jacquarda_bastarda_9_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -6612,6 +10020,9 @@
     "sane": "jacques_francois",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6620,6 +10031,9 @@
     "sane": "jacques_francois_shadow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6628,6 +10042,11 @@
     "sane": "jaini",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6636,6 +10055,11 @@
     "sane": "jaini_purva",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6645,6 +10069,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6653,6 +10082,11 @@
     "sane": "jaro",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6661,6 +10095,10 @@
     "sane": "jersey_10",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6669,6 +10107,10 @@
     "sane": "jersey_10_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6677,6 +10119,10 @@
     "sane": "jersey_15",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6685,6 +10131,10 @@
     "sane": "jersey_15_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6693,6 +10143,10 @@
     "sane": "jersey_20",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6701,6 +10155,10 @@
     "sane": "jersey_20_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6709,6 +10167,10 @@
     "sane": "jersey_25",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6717,6 +10179,10 @@
     "sane": "jersey_25_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6740,6 +10206,14 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6748,6 +10222,10 @@
     "sane": "jim_nightshade",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6756,6 +10234,10 @@
     "sane": "joan",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6764,6 +10246,10 @@
     "sane": "jockey_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6772,6 +10258,10 @@
     "sane": "jolly_lodger",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6780,6 +10270,10 @@
     "sane": "jomhuria",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6788,6 +10282,10 @@
     "sane": "jomolhari",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "tibetan"
     ]
   },
   {
@@ -6809,6 +10307,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6830,6 +10333,9 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6855,6 +10361,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6863,6 +10374,10 @@
     "sane": "joti_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6871,6 +10386,10 @@
     "sane": "jua",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -6881,6 +10400,11 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6889,6 +10413,10 @@
     "sane": "julee",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6897,6 +10425,10 @@
     "sane": "julius_sans_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6905,6 +10437,9 @@
     "sane": "junge",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -6917,6 +10452,16 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "kayah-li",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6925,6 +10470,10 @@
     "sane": "just_another_hand",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6933,6 +10482,10 @@
     "sane": "just_me_again_down_here",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6956,6 +10509,12 @@
       "1,700",
       "0,800",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -6964,6 +10523,13 @@
     "sane": "kablammo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -6973,6 +10539,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6983,6 +10554,12 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -6993,6 +10570,12 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7003,6 +10586,12 @@
       "0,400",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7014,6 +10603,12 @@
       "0,500",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7024,6 +10619,11 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7038,6 +10638,29 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Kalnia Glaze",
+    "sane": "kalnia_glaze",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7049,6 +10672,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7074,6 +10701,12 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -7095,6 +10728,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "khmer",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7105,6 +10743,11 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7126,6 +10769,10 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7138,6 +10785,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7146,6 +10798,11 @@
     "sane": "katibeh",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7154,6 +10811,10 @@
     "sane": "kaushan_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7162,6 +10823,11 @@
     "sane": "kavivanar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -7170,6 +10836,10 @@
     "sane": "kavoon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7181,6 +10851,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "kayah-li",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7189,6 +10864,11 @@
     "sane": "kdam_thmor_pro",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7197,6 +10877,10 @@
     "sane": "keania_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7205,6 +10889,11 @@
     "sane": "kelly_slab",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7213,6 +10902,9 @@
     "sane": "kenia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7225,6 +10917,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7237,6 +10934,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7245,6 +10947,11 @@
     "sane": "kings",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7253,6 +10960,10 @@
     "sane": "kirang_haerang",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -7261,6 +10972,10 @@
     "sane": "kite_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7271,6 +10986,12 @@
       "0,300",
       "0,400",
       "0,500"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7280,6 +11001,13 @@
     "variants": [
       "0,400",
       "0,600"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek-ext",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7288,6 +11016,10 @@
     "sane": "knewave",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7307,6 +11039,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -7318,6 +11056,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7330,6 +11072,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -7349,6 +11095,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -7357,6 +11109,11 @@
     "sane": "kolker_brush",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7365,6 +11122,11 @@
     "sane": "konkhmer_sleokchher",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7373,6 +11135,12 @@
     "sane": "kosugi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7381,6 +11149,12 @@
     "sane": "kosugi_maru",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7389,6 +11163,10 @@
     "sane": "kotta_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7397,6 +11175,10 @@
     "sane": "koulen",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -7405,6 +11187,9 @@
     "sane": "kranky",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7417,6 +11202,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7425,6 +11214,9 @@
     "sane": "kristi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7433,6 +11225,10 @@
     "sane": "krona_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7452,6 +11248,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -7471,6 +11273,12 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7488,6 +11296,10 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7504,6 +11316,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -7512,6 +11330,13 @@
     "sane": "kurale",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7520,6 +11345,10 @@
     "sane": "la_belle_aurore",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7545,6 +11374,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7553,6 +11387,9 @@
     "sane": "lacquer",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7565,6 +11402,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7573,6 +11415,10 @@
     "sane": "lakki_reddy",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -7581,6 +11427,12 @@
     "sane": "lalezar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7589,6 +11441,10 @@
     "sane": "lancelot",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7597,6 +11453,11 @@
     "sane": "langar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7611,6 +11472,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7628,6 +11494,10 @@
       "1,700",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7636,6 +11506,11 @@
     "sane": "lavishly_yours",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7644,6 +11519,11 @@
     "sane": "league_gothic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7652,6 +11532,9 @@
     "sane": "league_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7668,6 +11551,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7676,6 +11564,9 @@
     "sane": "leckerli_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7684,6 +11575,11 @@
     "sane": "ledger",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7694,6 +11590,10 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7702,6 +11602,10 @@
     "sane": "lemon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7714,6 +11618,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7730,6 +11640,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7746,6 +11661,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7762,6 +11682,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7778,6 +11703,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7794,6 +11724,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7810,6 +11745,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7826,6 +11766,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7842,6 +11787,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7850,6 +11800,9 @@
     "sane": "libre_barcode_128",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7858,6 +11811,9 @@
     "sane": "libre_barcode_128_text",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7866,6 +11822,9 @@
     "sane": "libre_barcode_39",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7874,6 +11833,9 @@
     "sane": "libre_barcode_39_extended",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7882,6 +11844,9 @@
     "sane": "libre_barcode_39_extended_text",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7890,6 +11855,9 @@
     "sane": "libre_barcode_39_text",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7898,6 +11866,9 @@
     "sane": "libre_barcode_ean13_text",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -7908,6 +11879,10 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7923,6 +11898,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7931,6 +11911,10 @@
     "sane": "libre_caslon_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7941,6 +11925,10 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7966,6 +11954,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7974,6 +11969,11 @@
     "sane": "licorice",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -7984,6 +11984,10 @@
       "0,400",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -7992,6 +11996,10 @@
     "sane": "lilita_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8000,6 +12008,10 @@
     "sane": "lily_script_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8008,6 +12020,10 @@
     "sane": "limelight",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8017,6 +12033,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8033,6 +12053,9 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8056,6 +12079,11 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "lisu"
     ]
   },
   {
@@ -8079,6 +12107,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8087,6 +12124,10 @@
     "sane": "liu_jian_mao_cao",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -8110,6 +12151,11 @@
       "1,700",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8118,6 +12164,13 @@
     "sane": "lobster",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8129,6 +12182,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8137,6 +12193,9 @@
     "sane": "londrina_outline",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8145,6 +12204,9 @@
     "sane": "londrina_shadow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8153,6 +12215,9 @@
     "sane": "londrina_sketch",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8164,6 +12229,9 @@
       "0,300",
       "0,400",
       "0,900"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8172,6 +12240,10 @@
     "sane": "long_cang",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -8187,6 +12259,15 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -8195,6 +12276,11 @@
     "sane": "love_light",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8203,6 +12289,10 @@
     "sane": "love_ya_like_a_sister",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8211,6 +12301,10 @@
     "sane": "loved_by_the_king",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8219,6 +12313,11 @@
     "sane": "lovers_quarrel",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8227,6 +12326,10 @@
     "sane": "luckiest_guy",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8235,6 +12338,10 @@
     "sane": "lugrasimo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8243,6 +12350,10 @@
     "sane": "lumanosimo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8252,6 +12363,16 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8261,6 +12382,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8269,6 +12393,9 @@
     "sane": "lustria",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8277,6 +12404,11 @@
     "sane": "luxurious_roman",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8285,6 +12417,11 @@
     "sane": "luxurious_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8295,6 +12432,17 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "chinese-hongkong",
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "lisu",
+      "vietnamese"
     ]
   },
   {
@@ -8305,6 +12453,17 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "chinese-hongkong",
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "lisu",
+      "vietnamese"
     ]
   },
   {
@@ -8321,6 +12480,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8335,6 +12500,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8349,6 +12520,17 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8365,6 +12547,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8379,6 +12567,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8393,6 +12586,17 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8401,6 +12605,10 @@
     "sane": "ma_shan_zheng",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -8409,6 +12617,9 @@
     "sane": "macondo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8417,6 +12628,9 @@
     "sane": "macondo_swash_caps",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8432,6 +12646,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8440,6 +12659,12 @@
     "sane": "madimi_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -8449,6 +12674,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8457,6 +12686,10 @@
     "sane": "maiden_orange",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8470,6 +12703,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -8478,6 +12717,11 @@
     "sane": "major_mono_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8486,6 +12730,10 @@
     "sane": "mako",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8505,6 +12753,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -8513,6 +12767,24 @@
     "sane": "mallanna",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
+    ]
+  },
+  {
+    "category": "serif",
+    "name": "Maname",
+    "sane": "maname",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala",
+      "vietnamese"
     ]
   },
   {
@@ -8521,6 +12793,10 @@
     "sane": "mandali",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -8531,6 +12807,11 @@
       "0,100",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "malayalam"
     ]
   },
   {
@@ -8545,6 +12826,14 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8553,6 +12842,12 @@
     "sane": "mansalva",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8572,6 +12867,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8580,6 +12880,10 @@
     "sane": "marcellus",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8588,6 +12892,10 @@
     "sane": "marcellus_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8596,6 +12904,11 @@
     "sane": "marck_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8604,6 +12917,10 @@
     "sane": "margarine",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8616,6 +12933,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8627,6 +12949,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8635,6 +12963,9 @@
     "sane": "marko_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8643,6 +12974,13 @@
     "sane": "marmelad",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8657,6 +12995,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8671,6 +13014,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8686,6 +13034,12 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8697,6 +13051,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8706,6 +13063,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8714,6 +13075,22 @@
     "sane": "mate_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Matemasie",
+    "sane": "matemasie",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8722,6 +13099,9 @@
     "sane": "material_icons",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8730,6 +13110,9 @@
     "sane": "material_icons_outlined",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8738,6 +13121,9 @@
     "sane": "material_icons_round",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8746,6 +13132,9 @@
     "sane": "material_icons_sharp",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8754,6 +13143,9 @@
     "sane": "material_icons_two_tone",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8768,6 +13160,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8782,6 +13177,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8796,6 +13194,9 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8809,6 +13210,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8817,6 +13223,10 @@
     "sane": "mclaren",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8825,6 +13235,11 @@
     "sane": "mea_culpa",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8833,6 +13248,10 @@
     "sane": "meddon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8841,6 +13260,10 @@
     "sane": "medievalsharp",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8849,6 +13272,9 @@
     "sane": "medula_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -8857,6 +13283,10 @@
     "sane": "meera_inimai",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "tamil"
     ]
   },
   {
@@ -8865,6 +13295,10 @@
     "sane": "megrim",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8873,6 +13307,10 @@
     "sane": "meie_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8881,6 +13319,11 @@
     "sane": "meow_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8895,6 +13338,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8910,6 +13358,13 @@
       "1,700",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8929,6 +13384,12 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8937,6 +13398,10 @@
     "sane": "metal",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -8945,6 +13410,10 @@
     "sane": "metal_mania",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8953,6 +13422,10 @@
     "sane": "metamorphous",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8961,6 +13434,11 @@
     "sane": "metrophobic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -8969,6 +13447,10 @@
     "sane": "michroma",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -8977,6 +13459,12 @@
     "sane": "micro_5",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -8985,6 +13473,12 @@
     "sane": "micro_5_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -8993,6 +13487,10 @@
     "sane": "milonga",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9001,6 +13499,9 @@
     "sane": "miltonian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9009,6 +13510,9 @@
     "sane": "miltonian_tattoo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9018,6 +13522,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9026,6 +13535,11 @@
     "sane": "mingzat",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "lepcha"
     ]
   },
   {
@@ -9034,6 +13548,9 @@
     "sane": "miniver",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9042,7 +13559,14 @@
     "sane": "miriam_libre",
     "variants": [
       "0,400",
+      "0,500",
+      "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9054,6 +13578,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9062,6 +13591,10 @@
     "sane": "miss_fajardose",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9075,6 +13608,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -9083,6 +13622,10 @@
     "sane": "mochiy_pop_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin"
     ]
   },
   {
@@ -9091,6 +13634,10 @@
     "sane": "mochiy_pop_p_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin"
     ]
   },
   {
@@ -9099,6 +13646,11 @@
     "sane": "modak",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9107,6 +13659,30 @@
     "sane": "modern_antiqua",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Moderustic",
+    "sane": "moderustic",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9115,6 +13691,11 @@
     "sane": "mogra",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9132,6 +13713,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9140,6 +13725,11 @@
     "sane": "moirai_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9148,6 +13738,10 @@
     "sane": "molengo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9156,6 +13750,38 @@
     "sane": "molle",
     "variants": [
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Mona Sans",
+    "sane": "mona_sans",
+    "variants": [
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900",
+      "1,200",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9164,7 +13790,14 @@
     "sane": "monda",
     "variants": [
       "0,400",
+      "0,500",
+      "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9173,6 +13806,10 @@
     "sane": "monofett",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9181,6 +13818,11 @@
     "sane": "monomaniac_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9189,6 +13831,10 @@
     "sane": "monoton",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9197,6 +13843,10 @@
     "sane": "monsieur_la_doulaise",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9205,6 +13855,9 @@
     "sane": "montaga",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9219,6 +13872,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9227,6 +13885,11 @@
     "sane": "montecarlo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9235,6 +13898,10 @@
     "sane": "montez",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9260,6 +13927,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9285,6 +13959,13 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9294,6 +13975,41 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Montserrat Underline",
+    "sane": "montserrat_underline",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9302,6 +14018,11 @@
     "sane": "moo_lah_lah",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9310,6 +14031,10 @@
     "sane": "mooli",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9318,6 +14043,11 @@
     "sane": "moon_dance",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9326,6 +14056,10 @@
     "sane": "moul",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -9334,6 +14068,10 @@
     "sane": "moulpali",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -9343,6 +14081,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9351,6 +14092,10 @@
     "sane": "mouse_memoirs",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9359,6 +14104,10 @@
     "sane": "mr_bedfort",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9367,6 +14116,10 @@
     "sane": "mr_dafoe",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9375,6 +14128,10 @@
     "sane": "mr_de_haviland",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9383,6 +14140,10 @@
     "sane": "mrs_saint_delafield",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9391,6 +14152,10 @@
     "sane": "mrs_sheppards",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9399,6 +14164,11 @@
     "sane": "ms_madi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9413,6 +14183,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9427,6 +14202,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9441,6 +14221,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -9455,6 +14240,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9478,6 +14268,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9494,6 +14291,14 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9519,6 +14324,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9527,6 +14337,11 @@
     "sane": "my_soul",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9535,6 +14350,12 @@
     "sane": "mynerve",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9543,6 +14364,10 @@
     "sane": "mystery_quest",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9551,6 +14376,13 @@
     "sane": "nabla",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "vietnamese"
     ]
   },
   {
@@ -9563,6 +14395,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "limbu"
     ]
   },
   {
@@ -9571,6 +14408,10 @@
     "sane": "nanum_brush_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -9581,6 +14422,10 @@
       "0,400",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -9590,6 +14435,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -9600,6 +14449,10 @@
       "0,400",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -9608,6 +14461,10 @@
     "sane": "nanum_pen_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -9620,6 +14477,13 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "gunjala-gondi",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -9628,6 +14492,11 @@
     "sane": "neonderthaw",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9636,6 +14505,10 @@
     "sane": "nerko_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9644,6 +14517,10 @@
     "sane": "neucha",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin"
     ]
   },
   {
@@ -9657,6 +14534,22 @@
       "1,400",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "New Amsterdam",
+    "sane": "new_amsterdam",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9665,6 +14558,10 @@
     "sane": "new_rocker",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9673,6 +14570,11 @@
     "sane": "new_tegomin",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9682,6 +14584,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9703,6 +14609,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9711,6 +14622,10 @@
     "sane": "niconne",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9730,6 +14645,12 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -9738,6 +14659,9 @@
     "sane": "nixie_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9751,6 +14675,10 @@
       "1,500",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9763,6 +14691,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -9771,6 +14703,10 @@
     "sane": "norican",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9779,6 +14715,10 @@
     "sane": "nosifer",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9787,6 +14727,9 @@
     "sane": "notable",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9795,6 +14738,9 @@
     "sane": "nothing_you_could_do",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -9806,6 +14752,11 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9822,6 +14773,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -9830,6 +14788,11 @@
     "sane": "noto_music",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "music"
     ]
   },
   {
@@ -9841,6 +14804,13 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -9852,6 +14822,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9868,6 +14843,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9893,6 +14874,16 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "devanagari",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -9904,6 +14895,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "adlam",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9915,6 +14911,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "adlam",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9923,6 +14924,11 @@
     "sane": "noto_sans_anatolian_hieroglyphs",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "anatolian-hieroglyphs",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9939,6 +14945,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "armenian",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9947,6 +14958,11 @@
     "sane": "noto_sans_avestan",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "avestan",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9958,6 +14974,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "balinese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9969,6 +14990,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "bamum",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9980,6 +15006,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "bassa-vah",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -9988,6 +15019,11 @@
     "sane": "noto_sans_batak",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "batak",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10004,6 +15040,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10012,6 +15053,11 @@
     "sane": "noto_sans_bhaiksuki",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "bhaiksuki",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10020,6 +15066,13 @@
     "sane": "noto_sans_brahmi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "brahmi",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -10028,6 +15081,11 @@
     "sane": "noto_sans_buginese",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "buginese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10036,6 +15094,11 @@
     "sane": "noto_sans_buhid",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "buhid",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10052,6 +15115,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "canadian-aboriginal",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -10060,6 +15130,11 @@
     "sane": "noto_sans_carian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "carian",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10068,6 +15143,11 @@
     "sane": "noto_sans_caucasian_albanian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "caucasian-albanian",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10076,6 +15156,11 @@
     "sane": "noto_sans_chakma",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chakma",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10092,6 +15177,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cham",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10108,6 +15198,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cherokee",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10116,6 +15211,13 @@
     "sane": "noto_sans_chorasmian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chorasmian",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -10124,6 +15226,11 @@
     "sane": "noto_sans_coptic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "coptic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10132,6 +15239,11 @@
     "sane": "noto_sans_cuneiform",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cuneiform",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10140,6 +15252,11 @@
     "sane": "noto_sans_cypriot",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cypriot",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10148,6 +15265,11 @@
     "sane": "noto_sans_cypro_minoan",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cypro-minoan",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10156,6 +15278,11 @@
     "sane": "noto_sans_deseret",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "deseret",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10172,6 +15299,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10197,6 +15329,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -10206,6 +15347,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "duployan",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10214,6 +15360,11 @@
     "sane": "noto_sans_egyptian_hieroglyphs",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "egyptian-hieroglyphs",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10222,6 +15373,11 @@
     "sane": "noto_sans_elbasan",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "elbasan",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10230,6 +15386,11 @@
     "sane": "noto_sans_elymaic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "elymaic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10246,6 +15407,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "ethiopic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10262,6 +15428,15 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "georgian",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -10270,6 +15445,14 @@
     "sane": "noto_sans_glagolitic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "glagolitic",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -10278,6 +15461,11 @@
     "sane": "noto_sans_gothic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gothic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10286,6 +15474,11 @@
     "sane": "noto_sans_grantha",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "grantha",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10302,6 +15495,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -10313,6 +15513,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "gunjala-gondi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10329,6 +15534,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10340,6 +15550,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "hanifi-rohingya",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10348,6 +15563,11 @@
     "sane": "noto_sans_hanunoo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hanunoo",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10356,6 +15576,11 @@
     "sane": "noto_sans_hatran",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hatran",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10372,6 +15597,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10388,6 +15620,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "chinese-hongkong",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -10396,6 +15635,11 @@
     "sane": "noto_sans_imperial_aramaic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "imperial-aramaic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10404,6 +15648,11 @@
     "sane": "noto_sans_indic_siyaq_numbers",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "indic-siyaq-numbers",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10412,6 +15661,11 @@
     "sane": "noto_sans_inscriptional_pahlavi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "inscriptional-pahlavi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10420,6 +15674,11 @@
     "sane": "noto_sans_inscriptional_parthian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "inscriptional-parthian",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10431,6 +15690,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "javanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10447,6 +15711,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -10455,6 +15726,11 @@
     "sane": "noto_sans_kaithi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "kaithi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10471,6 +15747,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10482,6 +15763,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "kawi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10493,6 +15779,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "kayah-li",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10501,6 +15792,11 @@
     "sane": "noto_sans_kharoshthi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "kharoshthi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10517,6 +15813,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10525,6 +15826,11 @@
     "sane": "noto_sans_khojki",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khojki",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10533,6 +15839,11 @@
     "sane": "noto_sans_khudawadi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khudawadi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10549,6 +15860,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -10565,6 +15883,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "lao",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10581,6 +15904,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "lao",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -10589,6 +15917,11 @@
     "sane": "noto_sans_lepcha",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "lepcha"
     ]
   },
   {
@@ -10597,6 +15930,11 @@
     "sane": "noto_sans_limbu",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "limbu"
     ]
   },
   {
@@ -10605,6 +15943,11 @@
     "sane": "noto_sans_linear_a",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "linear-a"
     ]
   },
   {
@@ -10613,6 +15956,11 @@
     "sane": "noto_sans_linear_b",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "linear-b"
     ]
   },
   {
@@ -10624,6 +15972,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "lisu"
     ]
   },
   {
@@ -10632,6 +15985,11 @@
     "sane": "noto_sans_lydian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "lydian"
     ]
   },
   {
@@ -10640,6 +15998,11 @@
     "sane": "noto_sans_mahajani",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "mahajani"
     ]
   },
   {
@@ -10656,6 +16019,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "malayalam"
     ]
   },
   {
@@ -10664,6 +16032,11 @@
     "sane": "noto_sans_mandaic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "mandaic"
     ]
   },
   {
@@ -10672,6 +16045,11 @@
     "sane": "noto_sans_manichaean",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "manichaean"
     ]
   },
   {
@@ -10680,6 +16058,11 @@
     "sane": "noto_sans_marchen",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "marchen"
     ]
   },
   {
@@ -10688,6 +16071,11 @@
     "sane": "noto_sans_masaram_gondi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "masaram-gondi"
     ]
   },
   {
@@ -10696,6 +16084,11 @@
     "sane": "noto_sans_mayan_numerals",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "mayan-numerals"
     ]
   },
   {
@@ -10707,6 +16100,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "medefaidrin"
     ]
   },
   {
@@ -10723,6 +16121,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "meetei-mayek"
     ]
   },
   {
@@ -10731,6 +16134,11 @@
     "sane": "noto_sans_mende_kikakui",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "mende-kikakui"
     ]
   },
   {
@@ -10739,6 +16147,13 @@
     "sane": "noto_sans_meroitic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "meroitic",
+      "meroitic-cursive",
+      "meroitic-hieroglyphs"
     ]
   },
   {
@@ -10747,6 +16162,11 @@
     "sane": "noto_sans_miao",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "miao"
     ]
   },
   {
@@ -10755,6 +16175,11 @@
     "sane": "noto_sans_modi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "modi"
     ]
   },
   {
@@ -10763,6 +16188,13 @@
     "sane": "noto_sans_mongolian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "mongolian",
+      "symbols"
     ]
   },
   {
@@ -10779,6 +16211,15 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -10787,6 +16228,11 @@
     "sane": "noto_sans_mro",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "mro"
     ]
   },
   {
@@ -10795,6 +16241,11 @@
     "sane": "noto_sans_multani",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "multani"
     ]
   },
   {
@@ -10803,6 +16254,11 @@
     "sane": "noto_sans_nabataean",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nabataean"
     ]
   },
   {
@@ -10814,6 +16270,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nag-mundari"
     ]
   },
   {
@@ -10822,6 +16283,11 @@
     "sane": "noto_sans_nandinagari",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nandinagari"
     ]
   },
   {
@@ -10833,6 +16299,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "new-tai-lue"
     ]
   },
   {
@@ -10841,6 +16312,11 @@
     "sane": "noto_sans_newa",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "newa"
     ]
   },
   {
@@ -10849,6 +16325,11 @@
     "sane": "noto_sans_nko",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nko"
     ]
   },
   {
@@ -10860,6 +16341,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nko"
     ]
   },
   {
@@ -10868,6 +16354,11 @@
     "sane": "noto_sans_nushu",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nushu"
     ]
   },
   {
@@ -10876,6 +16367,11 @@
     "sane": "noto_sans_ogham",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "ogham"
     ]
   },
   {
@@ -10887,6 +16383,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "ol-chiki"
     ]
   },
   {
@@ -10895,6 +16396,11 @@
     "sane": "noto_sans_old_hungarian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-hungarian"
     ]
   },
   {
@@ -10903,6 +16409,11 @@
     "sane": "noto_sans_old_italic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-italic"
     ]
   },
   {
@@ -10911,6 +16422,11 @@
     "sane": "noto_sans_old_north_arabian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-north-arabian"
     ]
   },
   {
@@ -10919,6 +16435,12 @@
     "sane": "noto_sans_old_permic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "old-permic"
     ]
   },
   {
@@ -10927,6 +16449,11 @@
     "sane": "noto_sans_old_persian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-persian"
     ]
   },
   {
@@ -10935,6 +16462,11 @@
     "sane": "noto_sans_old_sogdian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-sogdian"
     ]
   },
   {
@@ -10943,6 +16475,11 @@
     "sane": "noto_sans_old_south_arabian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-south-arabian"
     ]
   },
   {
@@ -10951,6 +16488,11 @@
     "sane": "noto_sans_old_turkic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-turkic"
     ]
   },
   {
@@ -10967,6 +16509,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "oriya"
     ]
   },
   {
@@ -10975,6 +16522,11 @@
     "sane": "noto_sans_osage",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "osage"
     ]
   },
   {
@@ -10983,6 +16535,11 @@
     "sane": "noto_sans_osmanya",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "osmanya"
     ]
   },
   {
@@ -10991,6 +16548,11 @@
     "sane": "noto_sans_pahawh_hmong",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "pahawh-hmong"
     ]
   },
   {
@@ -10999,6 +16561,11 @@
     "sane": "noto_sans_palmyrene",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "palmyrene"
     ]
   },
   {
@@ -11007,6 +16574,26 @@
     "sane": "noto_sans_pau_cin_hau",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "pau-cin-hau"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Noto Sans PhagsPa",
+    "sane": "noto_sans_phagspa",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "phags-pa",
+      "symbols"
     ]
   },
   {
@@ -11015,6 +16602,11 @@
     "sane": "noto_sans_phoenician",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "phoenician"
     ]
   },
   {
@@ -11023,6 +16615,11 @@
     "sane": "noto_sans_psalter_pahlavi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "psalter-pahlavi"
     ]
   },
   {
@@ -11031,6 +16628,11 @@
     "sane": "noto_sans_rejang",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "rejang"
     ]
   },
   {
@@ -11039,6 +16641,11 @@
     "sane": "noto_sans_runic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "runic"
     ]
   },
   {
@@ -11047,6 +16654,11 @@
     "sane": "noto_sans_samaritan",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "samaritan"
     ]
   },
   {
@@ -11055,6 +16667,11 @@
     "sane": "noto_sans_saurashtra",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "saurashtra"
     ]
   },
   {
@@ -11071,6 +16688,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11079,6 +16703,11 @@
     "sane": "noto_sans_sharada",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sharada"
     ]
   },
   {
@@ -11087,6 +16716,11 @@
     "sane": "noto_sans_shavian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "shavian"
     ]
   },
   {
@@ -11095,6 +16729,11 @@
     "sane": "noto_sans_siddham",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "siddham"
     ]
   },
   {
@@ -11103,6 +16742,11 @@
     "sane": "noto_sans_signwriting",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "signwriting"
     ]
   },
   {
@@ -11119,6 +16763,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala"
     ]
   },
   {
@@ -11127,6 +16776,11 @@
     "sane": "noto_sans_sogdian",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sogdian"
     ]
   },
   {
@@ -11138,6 +16792,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sora-sompeng"
     ]
   },
   {
@@ -11146,6 +16805,11 @@
     "sane": "noto_sans_soyombo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "soyombo"
     ]
   },
   {
@@ -11157,6 +16821,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sundanese"
     ]
   },
   {
@@ -11165,6 +16834,11 @@
     "sane": "noto_sans_syloti_nagri",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "syloti-nagri"
     ]
   },
   {
@@ -11181,6 +16855,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "symbols"
     ]
   },
   {
@@ -11189,6 +16868,14 @@
     "sane": "noto_sans_symbols_2",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "braille",
+      "latin",
+      "latin-ext",
+      "math",
+      "mayan-numerals",
+      "symbols"
     ]
   },
   {
@@ -11205,6 +16892,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "syriac"
     ]
   },
   {
@@ -11221,6 +16913,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "syriac"
     ]
   },
   {
@@ -11229,6 +16926,11 @@
     "sane": "noto_sans_tagalog",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tagalog"
     ]
   },
   {
@@ -11237,6 +16939,11 @@
     "sane": "noto_sans_tagbanwa",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tagbanwa"
     ]
   },
   {
@@ -11245,6 +16952,11 @@
     "sane": "noto_sans_tai_le",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tai-le"
     ]
   },
   {
@@ -11256,6 +16968,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tai-tham"
     ]
   },
   {
@@ -11264,6 +16981,11 @@
     "sane": "noto_sans_tai_viet",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tai-viet"
     ]
   },
   {
@@ -11272,6 +16994,11 @@
     "sane": "noto_sans_takri",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "takri"
     ]
   },
   {
@@ -11288,6 +17015,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -11296,6 +17028,11 @@
     "sane": "noto_sans_tamil_supplement",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil-supplement"
     ]
   },
   {
@@ -11307,6 +17044,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tangsa"
     ]
   },
   {
@@ -11323,6 +17065,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "chinese-traditional",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11339,6 +17088,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -11355,6 +17109,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thaana"
     ]
   },
   {
@@ -11371,6 +17130,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai"
     ]
   },
   {
@@ -11387,6 +17151,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai"
     ]
   },
   {
@@ -11395,6 +17164,11 @@
     "sane": "noto_sans_tifinagh",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tifinagh"
     ]
   },
   {
@@ -11403,6 +17177,11 @@
     "sane": "noto_sans_tirhuta",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tirhuta"
     ]
   },
   {
@@ -11411,6 +17190,11 @@
     "sane": "noto_sans_ugaritic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "ugaritic"
     ]
   },
   {
@@ -11419,6 +17203,11 @@
     "sane": "noto_sans_vai",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vai"
     ]
   },
   {
@@ -11430,6 +17219,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vithkuqi"
     ]
   },
   {
@@ -11438,6 +17232,11 @@
     "sane": "noto_sans_wancho",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "wancho"
     ]
   },
   {
@@ -11446,6 +17245,11 @@
     "sane": "noto_sans_warang_citi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "warang-citi"
     ]
   },
   {
@@ -11454,6 +17258,11 @@
     "sane": "noto_sans_yi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "yi"
     ]
   },
   {
@@ -11462,6 +17271,11 @@
     "sane": "noto_sans_zanabazar_square",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "zanabazar-square"
     ]
   },
   {
@@ -11487,6 +17301,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11495,6 +17318,11 @@
     "sane": "noto_serif_ahom",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "ahom",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11511,6 +17339,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "armenian",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11519,6 +17352,11 @@
     "sane": "noto_serif_balinese",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "balinese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11535,6 +17373,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11551,6 +17394,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11576,6 +17424,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11584,6 +17441,11 @@
     "sane": "noto_serif_dogra",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "dogra",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11600,6 +17462,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "ethiopic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11616,6 +17483,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "georgian",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11624,6 +17496,11 @@
     "sane": "noto_serif_grantha",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "grantha",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11640,6 +17517,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -11656,6 +17540,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11672,6 +17561,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11687,6 +17581,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "chinese-hongkong",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11702,6 +17603,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11718,6 +17626,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11726,6 +17639,11 @@
     "sane": "noto_serif_khitan_small_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khitan-small-script",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11742,6 +17660,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11753,6 +17676,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "khojki",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11768,6 +17696,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "korean",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11784,6 +17719,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "lao",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -11792,6 +17732,11 @@
     "sane": "noto_serif_makasar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "makasar"
     ]
   },
   {
@@ -11808,6 +17753,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "malayalam"
     ]
   },
   {
@@ -11819,6 +17769,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "nyiakeng-puachue-hmong"
     ]
   },
   {
@@ -11827,6 +17781,11 @@
     "sane": "noto_serif_old_uyghur",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "old-uyghur"
     ]
   },
   {
@@ -11838,6 +17797,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "oriya"
     ]
   },
   {
@@ -11846,6 +17810,11 @@
     "sane": "noto_serif_ottoman_siyaq",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "ottoman-siyaq-numbers"
     ]
   },
   {
@@ -11861,6 +17830,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11877,6 +17853,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala"
     ]
   },
   {
@@ -11902,6 +17883,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -11910,6 +17896,11 @@
     "sane": "noto_serif_tangut",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tangut"
     ]
   },
   {
@@ -11925,6 +17916,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "chinese-traditional",
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -11941,6 +17939,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -11957,6 +17960,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai"
     ]
   },
   {
@@ -11973,6 +17981,24 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tibetan"
+    ]
+  },
+  {
+    "category": "serif",
+    "name": "Noto Serif Todhri",
+    "sane": "noto_serif_todhri",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "todhri"
     ]
   },
   {
@@ -11984,6 +18010,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "toto"
     ]
   },
   {
@@ -11995,6 +18026,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vithkuqi"
     ]
   },
   {
@@ -12006,6 +18042,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "yezidi"
     ]
   },
   {
@@ -12018,6 +18059,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "nushu"
     ]
   },
   {
@@ -12026,6 +18072,13 @@
     "sane": "noto_znamenny_musical_notation",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "znamenny"
     ]
   },
   {
@@ -12034,6 +18087,10 @@
     "sane": "nova_cut",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12042,6 +18099,10 @@
     "sane": "nova_flat",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12050,6 +18111,11 @@
     "sane": "nova_mono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12058,6 +18124,10 @@
     "sane": "nova_oval",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12066,6 +18136,10 @@
     "sane": "nova_round",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12074,6 +18148,10 @@
     "sane": "nova_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12082,6 +18160,10 @@
     "sane": "nova_slim",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12090,6 +18172,10 @@
     "sane": "nova_square",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12098,6 +18184,10 @@
     "sane": "ntr",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -12106,6 +18196,9 @@
     "sane": "numans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12129,6 +18222,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12152,6 +18252,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12160,6 +18267,11 @@
     "sane": "nuosu_sil",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "yi"
     ]
   },
   {
@@ -12168,6 +18280,9 @@
     "sane": "odibee_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12176,6 +18291,10 @@
     "sane": "odor_mean_chey",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -12184,6 +18303,10 @@
     "sane": "offside",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12192,6 +18315,16 @@
     "sane": "oi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "tamil",
+      "vietnamese"
     ]
   },
   {
@@ -12206,6 +18339,13 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -12216,6 +18356,13 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12224,6 +18371,10 @@
     "sane": "oldenburg",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12232,6 +18383,11 @@
     "sane": "ole",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12241,6 +18397,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12250,6 +18410,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12266,6 +18430,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12274,6 +18444,11 @@
     "sane": "oooh_baby",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12293,6 +18468,18 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -12301,6 +18488,12 @@
     "sane": "oranienbaum",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12309,6 +18502,11 @@
     "sane": "orbit",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12322,6 +18520,9 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12331,6 +18532,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12339,6 +18544,12 @@
     "sane": "orelega_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12347,6 +18558,10 @@
     "sane": "orienta",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12355,6 +18570,10 @@
     "sane": "original_surfer",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12368,6 +18587,13 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12384,6 +18610,10 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12392,6 +18622,10 @@
     "sane": "over_the_rainbow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12405,6 +18639,10 @@
       "1,700",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12413,6 +18651,10 @@
     "sane": "overlock_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12438,6 +18680,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12450,6 +18699,13 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12458,6 +18714,9 @@
     "sane": "ovo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12472,6 +18731,10 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12482,6 +18745,10 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12490,6 +18757,10 @@
     "sane": "oxygen_mono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12498,6 +18769,13 @@
     "sane": "pacifico",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12507,6 +18785,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "myanmar"
     ]
   },
   {
@@ -12515,6 +18798,11 @@
     "sane": "padyakke_expanded_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12529,6 +18817,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12540,6 +18833,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12548,6 +18846,10 @@
     "sane": "palette_mosaic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin"
     ]
   },
   {
@@ -12556,6 +18858,13 @@
     "sane": "pangolin",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12564,6 +18873,10 @@
     "sane": "paprika",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12572,6 +18885,27 @@
     "sane": "parisienne",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Parkinsans",
+    "sane": "parkinsans",
+    "variants": [
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12580,6 +18914,10 @@
     "sane": "passero_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12590,6 +18928,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12598,6 +18940,11 @@
     "sane": "passions_conflict",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12623,6 +18970,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12631,6 +18983,10 @@
     "sane": "pathway_gothic_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12639,6 +18995,11 @@
     "sane": "patrick_hand",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12647,6 +19008,11 @@
     "sane": "patrick_hand_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12655,6 +19021,13 @@
     "sane": "pattaya",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -12663,6 +19036,9 @@
     "sane": "patua_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12671,6 +19047,11 @@
     "sane": "pavanam",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -12679,6 +19060,11 @@
     "sane": "paytone_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12687,6 +19073,10 @@
     "sane": "peddana",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -12695,6 +19085,10 @@
     "sane": "peralta",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12703,6 +19097,9 @@
     "sane": "permanent_marker",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12711,6 +19108,11 @@
     "sane": "petemoss",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12719,6 +19121,10 @@
     "sane": "petit_formal_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12744,6 +19150,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12755,6 +19166,13 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12769,6 +19187,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12794,6 +19218,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12802,6 +19235,10 @@
     "sane": "piedra",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12810,6 +19247,11 @@
     "sane": "pinyon_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12818,6 +19260,10 @@
     "sane": "pirata_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12829,6 +19275,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12837,6 +19288,10 @@
     "sane": "plaster",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12856,6 +19311,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12865,6 +19325,14 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12873,6 +19341,11 @@
     "sane": "playball",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12894,6 +19367,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12913,6 +19393,12 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12926,6 +19412,12 @@
       "1,700",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12941,6 +19433,1303 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "emoji",
+      "latin",
+      "latin-ext",
+      "math",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AR",
+    "sane": "playwrite_ar",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AR Guides",
+    "sane": "playwrite_ar_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AT",
+    "sane": "playwrite_at",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AT Guides",
+    "sane": "playwrite_at_guides",
+    "variants": [
+      "0,400",
+      "1,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU NSW",
+    "sane": "playwrite_au_nsw",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU NSW Guides",
+    "sane": "playwrite_au_nsw_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU QLD",
+    "sane": "playwrite_au_qld",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU QLD Guides",
+    "sane": "playwrite_au_qld_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU SA",
+    "sane": "playwrite_au_sa",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU SA Guides",
+    "sane": "playwrite_au_sa_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU TAS",
+    "sane": "playwrite_au_tas",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU TAS Guides",
+    "sane": "playwrite_au_tas_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU VIC",
+    "sane": "playwrite_au_vic",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite AU VIC Guides",
+    "sane": "playwrite_au_vic_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite BE VLG",
+    "sane": "playwrite_be_vlg",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite BE VLG Guides",
+    "sane": "playwrite_be_vlg_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite BE WAL",
+    "sane": "playwrite_be_wal",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite BE WAL Guides",
+    "sane": "playwrite_be_wal_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite BR",
+    "sane": "playwrite_br",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite BR Guides",
+    "sane": "playwrite_br_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CA",
+    "sane": "playwrite_ca",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CA Guides",
+    "sane": "playwrite_ca_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CL",
+    "sane": "playwrite_cl",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CL Guides",
+    "sane": "playwrite_cl_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CO",
+    "sane": "playwrite_co",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CO Guides",
+    "sane": "playwrite_co_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CU",
+    "sane": "playwrite_cu",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CU Guides",
+    "sane": "playwrite_cu_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CZ",
+    "sane": "playwrite_cz",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite CZ Guides",
+    "sane": "playwrite_cz_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE Grund",
+    "sane": "playwrite_de_grund",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE Grund Guides",
+    "sane": "playwrite_de_grund_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE LA",
+    "sane": "playwrite_de_la",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE LA Guides",
+    "sane": "playwrite_de_la_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE SAS",
+    "sane": "playwrite_de_sas",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE SAS Guides",
+    "sane": "playwrite_de_sas_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE VA",
+    "sane": "playwrite_de_va",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DE VA Guides",
+    "sane": "playwrite_de_va_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DK Loopet",
+    "sane": "playwrite_dk_loopet",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DK Loopet Guides",
+    "sane": "playwrite_dk_loopet_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DK Uloopet",
+    "sane": "playwrite_dk_uloopet",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite DK Uloopet Guides",
+    "sane": "playwrite_dk_uloopet_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ES",
+    "sane": "playwrite_es",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ES Deco",
+    "sane": "playwrite_es_deco",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ES Deco Guides",
+    "sane": "playwrite_es_deco_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ES Guides",
+    "sane": "playwrite_es_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite FR Moderne",
+    "sane": "playwrite_fr_moderne",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite FR Moderne Guides",
+    "sane": "playwrite_fr_moderne_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite FR Trad",
+    "sane": "playwrite_fr_trad",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite FR Trad Guides",
+    "sane": "playwrite_fr_trad_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite GB J",
+    "sane": "playwrite_gb_j",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite GB J Guides",
+    "sane": "playwrite_gb_j_guides",
+    "variants": [
+      "0,400",
+      "1,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite GB S",
+    "sane": "playwrite_gb_s",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite GB S Guides",
+    "sane": "playwrite_gb_s_guides",
+    "variants": [
+      "0,400",
+      "1,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite HR",
+    "sane": "playwrite_hr",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite HR Guides",
+    "sane": "playwrite_hr_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite HR Lijeva",
+    "sane": "playwrite_hr_lijeva",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite HR Lijeva Guides",
+    "sane": "playwrite_hr_lijeva_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite HU",
+    "sane": "playwrite_hu",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite HU Guides",
+    "sane": "playwrite_hu_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ID",
+    "sane": "playwrite_id",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ID Guides",
+    "sane": "playwrite_id_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IE",
+    "sane": "playwrite_ie",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IE Guides",
+    "sane": "playwrite_ie_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IN",
+    "sane": "playwrite_in",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IN Guides",
+    "sane": "playwrite_in_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IS",
+    "sane": "playwrite_is",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IS Guides",
+    "sane": "playwrite_is_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IT Moderna",
+    "sane": "playwrite_it_moderna",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IT Moderna Guides",
+    "sane": "playwrite_it_moderna_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IT Trad",
+    "sane": "playwrite_it_trad",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite IT Trad Guides",
+    "sane": "playwrite_it_trad_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite MX",
+    "sane": "playwrite_mx",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite MX Guides",
+    "sane": "playwrite_mx_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NG Modern",
+    "sane": "playwrite_ng_modern",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NG Modern Guides",
+    "sane": "playwrite_ng_modern_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NL",
+    "sane": "playwrite_nl",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NL Guides",
+    "sane": "playwrite_nl_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NO",
+    "sane": "playwrite_no",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NO Guides",
+    "sane": "playwrite_no_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NZ",
+    "sane": "playwrite_nz",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite NZ Guides",
+    "sane": "playwrite_nz_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite PE",
+    "sane": "playwrite_pe",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite PE Guides",
+    "sane": "playwrite_pe_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite PL",
+    "sane": "playwrite_pl",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite PL Guides",
+    "sane": "playwrite_pl_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite PT",
+    "sane": "playwrite_pt",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite PT Guides",
+    "sane": "playwrite_pt_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite RO",
+    "sane": "playwrite_ro",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite RO Guides",
+    "sane": "playwrite_ro_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite SK",
+    "sane": "playwrite_sk",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite SK Guides",
+    "sane": "playwrite_sk_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite TZ",
+    "sane": "playwrite_tz",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite TZ Guides",
+    "sane": "playwrite_tz_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite US Modern",
+    "sane": "playwrite_us_modern",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite US Modern Guides",
+    "sane": "playwrite_us_modern_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite US Trad",
+    "sane": "playwrite_us_trad",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite US Trad Guides",
+    "sane": "playwrite_us_trad_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite VN",
+    "sane": "playwrite_vn",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite VN Guides",
+    "sane": "playwrite_vn_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ZA",
+    "sane": "playwrite_za",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "handwriting",
+    "name": "Playwrite ZA Guides",
+    "sane": "playwrite_za_guides",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -12962,6 +20751,12 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12974,6 +20769,13 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -12982,6 +20784,10 @@
     "sane": "poetsen_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12990,6 +20796,11 @@
     "sane": "poiret_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -12998,6 +20809,9 @@
     "sane": "poller_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13013,6 +20827,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13022,6 +20841,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13030,6 +20853,21 @@
     "sane": "pompiere",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "display",
+    "name": "Ponnala",
+    "sane": "ponnala",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -13042,6 +20880,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13050,6 +20892,10 @@
     "sane": "poor_story",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -13075,6 +20921,10 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13083,6 +20933,9 @@
     "sane": "port_lligat_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13091,6 +20944,9 @@
     "sane": "port_lligat_slab",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13099,6 +20955,12 @@
     "sane": "potta_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13108,6 +20970,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13116,6 +20983,11 @@
     "sane": "praise",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13124,6 +20996,12 @@
     "sane": "prata",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ]
   },
   {
@@ -13132,6 +21010,10 @@
     "sane": "preahvihear",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -13140,6 +21022,13 @@
     "sane": "press_start_2p",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13153,6 +21042,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -13161,6 +21056,10 @@
     "sane": "princess_sofia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13169,6 +21068,9 @@
     "sane": "prociono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13194,6 +21096,12 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -13202,6 +21110,11 @@
     "sane": "prosto_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13210,6 +21123,13 @@
     "sane": "protest_guerrilla",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -13218,6 +21138,13 @@
     "sane": "protest_revolution",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -13226,6 +21153,13 @@
     "sane": "protest_riot",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -13234,6 +21168,13 @@
     "sane": "protest_strike",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -13251,6 +21192,10 @@
       "1,700",
       "0,800",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13259,6 +21204,12 @@
     "sane": "pt_mono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13270,6 +21221,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13279,6 +21236,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13288,6 +21251,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13299,6 +21268,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13308,6 +21283,12 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13333,6 +21314,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13341,6 +21327,11 @@
     "sane": "puppies_play",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13352,6 +21343,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13360,6 +21354,10 @@
     "sane": "purple_purse",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13368,6 +21366,10 @@
     "sane": "qahiri",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin"
     ]
   },
   {
@@ -13376,6 +21378,10 @@
     "sane": "quando",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13387,6 +21393,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13396,6 +21405,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13407,6 +21420,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13415,6 +21432,11 @@
     "sane": "questrial",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13427,6 +21449,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13435,6 +21462,10 @@
     "sane": "quintessential",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13443,6 +21474,11 @@
     "sane": "qwigley",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13452,6 +21488,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13460,6 +21501,10 @@
     "sane": "racing_sans_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13477,6 +21522,12 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "canadian-aboriginal",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13492,6 +21543,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13501,6 +21556,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13513,6 +21572,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13521,6 +21585,11 @@
     "sane": "rakkas",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13546,6 +21615,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13554,6 +21630,10 @@
     "sane": "raleway_dots",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13562,6 +21642,10 @@
     "sane": "ramabhadra",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -13570,6 +21654,10 @@
     "sane": "ramaraja",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -13581,6 +21669,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13589,6 +21681,10 @@
     "sane": "rammetto_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13597,6 +21693,12 @@
     "sane": "rampart_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13605,6 +21707,10 @@
     "sane": "ranchers",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13613,6 +21719,9 @@
     "sane": "rancho",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13622,6 +21731,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13639,6 +21753,12 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13647,6 +21767,9 @@
     "sane": "rationale",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13655,6 +21778,10 @@
     "sane": "ravi_prakash",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -13668,6 +21795,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13682,6 +21815,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13703,6 +21842,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13720,6 +21863,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13737,6 +21884,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13749,6 +21900,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13757,6 +21913,10 @@
     "sane": "redacted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13767,6 +21927,10 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13782,6 +21946,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13805,6 +21974,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13820,6 +21994,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13828,6 +22007,10 @@
     "sane": "redressed",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13839,6 +22022,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13850,6 +22039,12 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13858,6 +22053,12 @@
     "sane": "reem_kufi_ink",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13866,6 +22067,9 @@
     "sane": "reenie_beanie",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -13874,6 +22078,12 @@
     "sane": "reggae_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13899,6 +22109,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13916,6 +22131,10 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13924,6 +22143,10 @@
     "sane": "revalia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13932,6 +22155,11 @@
     "sane": "rhodium_libre",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13940,6 +22168,10 @@
     "sane": "ribeye",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13948,6 +22180,10 @@
     "sane": "ribeye_marrow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13956,6 +22192,10 @@
     "sane": "righteous",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13964,6 +22204,10 @@
     "sane": "risque",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -13972,6 +22216,11 @@
     "sane": "road_rage",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -13980,17 +22229,34 @@
     "sane": "roboto",
     "variants": [
       "0,100",
-      "1,100",
+      "0,200",
       "0,300",
-      "1,300",
       "0,400",
-      "1,400",
       "0,500",
-      "1,500",
+      "0,600",
       "0,700",
-      "1,700",
+      "0,800",
       "0,900",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -14016,6 +22282,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14024,6 +22299,14 @@
     "sane": "roboto_flex",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14045,6 +22328,14 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14070,6 +22361,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14086,6 +22384,15 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14094,6 +22401,9 @@
     "sane": "rochester",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -14102,6 +22412,10 @@
     "sane": "rock_3d",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin"
     ]
   },
   {
@@ -14110,6 +22424,9 @@
     "sane": "rock_salt",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -14118,6 +22435,11 @@
     "sane": "rocknroll_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14143,6 +22465,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14151,6 +22478,10 @@
     "sane": "romanesco",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14160,6 +22491,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14177,6 +22512,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14186,6 +22526,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14194,6 +22538,9 @@
     "sane": "rouge_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -14204,6 +22551,11 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14212,6 +22564,11 @@
     "sane": "rozha_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14233,6 +22590,14 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "arabic",
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14241,6 +22606,13 @@
     "sane": "rubik_80s_fade",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14249,6 +22621,13 @@
     "sane": "rubik_beastly",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14257,6 +22636,15 @@
     "sane": "rubik_broken_fax",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14265,6 +22653,13 @@
     "sane": "rubik_bubbles",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14273,6 +22668,13 @@
     "sane": "rubik_burned",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14281,6 +22683,13 @@
     "sane": "rubik_dirt",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14289,6 +22698,13 @@
     "sane": "rubik_distressed",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14297,6 +22713,15 @@
     "sane": "rubik_doodle_shadow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14305,6 +22730,15 @@
     "sane": "rubik_doodle_triangles",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14313,6 +22747,13 @@
     "sane": "rubik_gemstones",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14321,6 +22762,13 @@
     "sane": "rubik_glitch",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14329,6 +22777,15 @@
     "sane": "rubik_glitch_pop",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14337,6 +22794,13 @@
     "sane": "rubik_iso",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14345,6 +22809,15 @@
     "sane": "rubik_lines",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14353,6 +22826,15 @@
     "sane": "rubik_maps",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14361,6 +22843,13 @@
     "sane": "rubik_marker_hatch",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14369,6 +22858,13 @@
     "sane": "rubik_maze",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14377,6 +22873,13 @@
     "sane": "rubik_microbe",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14385,6 +22888,11 @@
     "sane": "rubik_mono_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14393,6 +22901,13 @@
     "sane": "rubik_moonrocks",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14401,6 +22916,13 @@
     "sane": "rubik_pixels",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14409,6 +22931,13 @@
     "sane": "rubik_puddles",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14417,6 +22946,15 @@
     "sane": "rubik_scribble",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14425,6 +22963,13 @@
     "sane": "rubik_spray_paint",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14433,6 +22978,13 @@
     "sane": "rubik_storm",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14441,6 +22993,13 @@
     "sane": "rubik_vinyl",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14449,6 +23008,13 @@
     "sane": "rubik_wet_paint",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14462,6 +23028,12 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14471,6 +23043,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14479,6 +23055,11 @@
     "sane": "ruge_boogie",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14487,6 +23068,10 @@
     "sane": "ruluko",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14495,6 +23080,10 @@
     "sane": "rum_raisin",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14503,6 +23092,13 @@
     "sane": "ruslan_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -14511,6 +23107,11 @@
     "sane": "russo_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14519,6 +23120,11 @@
     "sane": "ruthie",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14530,6 +23136,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14538,6 +23149,10 @@
     "sane": "rye",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14546,6 +23161,10 @@
     "sane": "sacramento",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14555,6 +23174,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14563,6 +23187,10 @@
     "sane": "sail",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14588,6 +23216,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14604,6 +23237,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14620,6 +23258,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14636,6 +23279,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14644,6 +23292,11 @@
     "sane": "saira_stencil_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14652,6 +23305,9 @@
     "sane": "salsa",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -14661,6 +23317,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14669,6 +23329,23 @@
     "sane": "sancreek",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Sankofa Display",
+    "sane": "sankofa_display",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14684,6 +23361,10 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14698,6 +23379,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14721,6 +23407,12 @@
       "1,700",
       "0,800",
       "1,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -14730,6 +23422,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14738,6 +23435,10 @@
     "sane": "sarina",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14751,6 +23452,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14759,6 +23465,11 @@
     "sane": "sassy_frass",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14767,6 +23478,9 @@
     "sane": "satisfy",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -14775,6 +23489,13 @@
     "sane": "sawarabi_gothic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14783,6 +23504,11 @@
     "sane": "sawarabi_mincho",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14794,6 +23520,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14805,6 +23537,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14824,6 +23561,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14832,6 +23573,9 @@
     "sane": "schoolbell",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -14840,6 +23584,10 @@
     "sane": "scope_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14848,6 +23596,10 @@
     "sane": "seaweed_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14856,6 +23608,11 @@
     "sane": "secular_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14865,6 +23622,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14873,6 +23634,10 @@
     "sane": "sedan_sc",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14881,6 +23646,11 @@
     "sane": "sedgwick_ave",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14889,6 +23659,11 @@
     "sane": "sedgwick_ave_display",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14901,6 +23676,10 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14909,6 +23688,11 @@
     "sane": "send_flowers",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14917,6 +23701,10 @@
     "sane": "sevillana",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14925,6 +23713,11 @@
     "sane": "seymour_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14933,6 +23726,10 @@
     "sane": "shadows_into_light",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14941,6 +23738,10 @@
     "sane": "shadows_into_light_two",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14949,6 +23750,11 @@
     "sane": "shalimar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14968,6 +23774,13 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -14976,6 +23789,10 @@
     "sane": "shanti",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14987,6 +23804,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -14995,6 +23816,9 @@
     "sane": "share_tech",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15003,6 +23827,9 @@
     "sane": "share_tech_mono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15011,6 +23838,11 @@
     "sane": "shippori_antique",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15019,6 +23851,11 @@
     "sane": "shippori_antique_b1",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15031,6 +23868,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15043,6 +23885,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15051,6 +23898,10 @@
     "sane": "shizuru",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin"
     ]
   },
   {
@@ -15059,6 +23910,10 @@
     "sane": "shojumaru",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15067,6 +23922,9 @@
     "sane": "short_stack",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15075,6 +23933,11 @@
     "sane": "shrikhand",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "gujarati",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15083,6 +23946,11 @@
     "sane": "sigmar",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15091,6 +23959,11 @@
     "sane": "sigmar_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15103,6 +23976,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15115,6 +23993,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15124,6 +24007,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15135,6 +24022,10 @@
       "1,400",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15144,6 +24035,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15152,6 +24047,9 @@
     "sane": "sirin_stencil",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15160,6 +24058,10 @@
     "sane": "six_caps",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15168,6 +24070,26 @@
     "sane": "sixtyfour",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
+    ]
+  },
+  {
+    "category": "monospace",
+    "name": "Sixtyfour Convergence",
+    "sane": "sixtyfour_convergence",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -15177,6 +24099,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15185,6 +24111,10 @@
     "sane": "slabo_13px",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15193,6 +24123,10 @@
     "sane": "slabo_27px",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15201,6 +24135,9 @@
     "sane": "slackey",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15209,6 +24146,11 @@
     "sane": "slackside_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15217,6 +24159,10 @@
     "sane": "smokum",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15225,6 +24171,11 @@
     "sane": "smooch",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15241,6 +24192,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15249,6 +24205,9 @@
     "sane": "smythe",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15258,6 +24217,10 @@
     "variants": [
       "0,400",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15266,6 +24229,9 @@
     "sane": "snippet",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15274,6 +24240,10 @@
     "sane": "snowburst_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15282,6 +24252,9 @@
     "sane": "sofadi_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15290,6 +24263,9 @@
     "sane": "sofia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15315,6 +24291,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15340,6 +24323,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15365,6 +24355,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15390,6 +24387,13 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15398,6 +24402,11 @@
     "sane": "solitreo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15410,6 +24419,9 @@
       "0,500",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15425,14 +24437,10 @@
       "1,500",
       "1,600",
       "1,700"
-    ]
-  },
-  {
-    "category": "serif",
-    "name": "Song Myung",
-    "sane": "song_myung",
-    "variants": [
-      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15447,6 +24455,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15455,6 +24468,10 @@
     "sane": "sonsie_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15470,6 +24487,10 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15479,6 +24500,39 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Sour Gummy",
+    "sane": "sour_gummy",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900",
+      "1,100",
+      "1,200",
+      "1,300",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15502,6 +24556,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15525,6 +24588,15 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15548,6 +24620,14 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15560,6 +24640,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15571,6 +24656,11 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15579,6 +24669,10 @@
     "sane": "special_elite",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15600,6 +24694,13 @@
       "1,700",
       "0,800",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15621,6 +24722,13 @@
       "1,700",
       "0,800",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15629,6 +24737,10 @@
     "sane": "spicy_rice",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15637,6 +24749,10 @@
     "sane": "spinnaker",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15645,6 +24761,9 @@
     "sane": "spirax",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15653,6 +24772,11 @@
     "sane": "splash",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15665,6 +24789,10 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15682,6 +24810,10 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15690,6 +24822,9 @@
     "sane": "squada_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15698,6 +24833,11 @@
     "sane": "square_peg",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15706,6 +24846,10 @@
     "sane": "sree_krushnadevaraya",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -15714,6 +24858,12 @@
     "sane": "sriracha",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -15723,6 +24873,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -15731,6 +24887,10 @@
     "sane": "staatliches",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15739,6 +24899,10 @@
     "sane": "stalemate",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15747,6 +24911,11 @@
     "sane": "stalinist_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15756,6 +24925,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15764,6 +24936,12 @@
     "sane": "stick",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15778,6 +24956,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala"
     ]
   },
   {
@@ -15786,6 +24969,10 @@
     "sane": "stint_ultra_condensed",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15794,6 +24981,10 @@
     "sane": "stint_ultra_expanded",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15809,6 +25000,14 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15818,6 +25017,10 @@
     "variants": [
       "0,300",
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15826,6 +25029,10 @@
     "sane": "strait",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15834,14 +25041,11 @@
     "sane": "style_script",
     "variants": [
       "0,400"
-    ]
-  },
-  {
-    "category": "sans-serif",
-    "name": "Stylish",
-    "sane": "stylish",
-    "variants": [
-      "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -15850,6 +25054,9 @@
     "sane": "sue_ellen_francisco",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15858,6 +25065,11 @@
     "sane": "suez_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15868,6 +25080,10 @@
       "0,300",
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15877,6 +25093,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15887,6 +25108,10 @@
       "0,300",
       "0,500",
       "0,700"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -15895,6 +25120,9 @@
     "sane": "sunshiney",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -15903,6 +25131,10 @@
     "sane": "supermercado_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15912,6 +25144,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15920,6 +25157,10 @@
     "sane": "suranna",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -15928,6 +25169,29 @@
     "sane": "suravaram",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "SUSE",
+    "sane": "suse",
+    "variants": [
+      "0,100",
+      "0,200",
+      "0,300",
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15940,6 +25204,10 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -15948,6 +25216,10 @@
     "sane": "swanky_and_moo_moo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15957,6 +25229,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15969,6 +25245,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15977,6 +25258,10 @@
     "sane": "syne_mono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15985,6 +25270,10 @@
     "sane": "syne_tactile",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -15993,6 +25282,13 @@
     "sane": "tac_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -16002,6 +25298,12 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tai-viet",
+      "vietnamese"
     ]
   },
   {
@@ -16016,6 +25318,10 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin"
     ]
   },
   {
@@ -16025,6 +25331,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16033,6 +25342,11 @@
     "sane": "tapestry",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16041,6 +25355,10 @@
     "sane": "taprom",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "khmer",
+      "latin"
     ]
   },
   {
@@ -16049,6 +25367,10 @@
     "sane": "tauri",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16074,6 +25396,12 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -16091,6 +25419,11 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16103,6 +25436,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16116,6 +25454,14 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16124,6 +25470,10 @@
     "sane": "telex",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16132,6 +25482,10 @@
     "sane": "tenali_ramakrishna",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -16140,6 +25494,11 @@
     "sane": "tenor_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16148,6 +25507,10 @@
     "sane": "text_me_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16173,6 +25536,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16184,6 +25552,12 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -16192,6 +25566,10 @@
     "sane": "the_girl_next_door",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16201,6 +25579,11 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16211,6 +25594,9 @@
       "0,400",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16223,6 +25609,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16231,6 +25622,11 @@
     "sane": "tilt_neon",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16239,6 +25635,11 @@
     "sane": "tilt_prism",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16247,6 +25648,11 @@
     "sane": "tilt_warp",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16255,6 +25661,10 @@
     "sane": "timmana",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "telugu"
     ]
   },
   {
@@ -16266,6 +25676,31 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Tiny5",
+    "sane": "tiny5",
+    "variants": [
+      "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16275,6 +25710,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "bengali",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16284,6 +25724,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16293,6 +25738,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16302,6 +25752,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16311,6 +25766,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "gurmukhi",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16320,6 +25780,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "kannada",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16329,6 +25794,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "tamil"
     ]
   },
   {
@@ -16338,6 +25808,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "telugu"
     ]
   },
   {
@@ -16346,6 +25821,10 @@
     "sane": "titan_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16364,6 +25843,10 @@
       "0,700",
       "1,700",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16389,6 +25872,10 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16414,6 +25901,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16422,6 +25914,9 @@
     "sane": "trade_winds",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16430,6 +25925,12 @@
     "sane": "train_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16455,6 +25956,12 @@
       "1,800",
       "0,900",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "thai",
+      "vietnamese"
     ]
   },
   {
@@ -16470,6 +25977,11 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16478,6 +25990,10 @@
     "sane": "trocchi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16488,6 +26004,9 @@
       "0,400",
       "1,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16504,6 +26023,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16512,6 +26036,10 @@
     "sane": "trykker",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16524,6 +26052,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16532,6 +26065,9 @@
     "sane": "tulpen_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16545,6 +26081,10 @@
       "0,500",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16553,6 +26093,11 @@
     "sane": "twinkle_star",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16568,6 +26113,14 @@
       "1,500",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16576,6 +26129,14 @@
     "sane": "ubuntu_condensed",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16587,6 +26148,14 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16610,6 +26179,14 @@
       "1,600",
       "1,700",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16625,6 +26202,14 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16633,6 +26218,10 @@
     "sane": "uchen",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "tibetan"
     ]
   },
   {
@@ -16641,6 +26230,10 @@
     "sane": "ultra",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16656,6 +26249,13 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16664,6 +26264,10 @@
     "sane": "uncial_antiqua",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16672,6 +26276,11 @@
     "sane": "underdog",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16680,6 +26289,11 @@
     "sane": "unica_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16688,6 +26302,9 @@
     "sane": "unifrakturcook",
     "variants": [
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16696,6 +26313,9 @@
     "sane": "unifrakturmaguntia",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16705,6 +26325,9 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16713,6 +26336,10 @@
     "sane": "unlock",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16724,6 +26351,10 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16732,6 +26363,11 @@
     "sane": "updock",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16757,6 +26393,10 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16765,6 +26405,10 @@
     "sane": "vampiro_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16773,6 +26417,10 @@
     "sane": "varela",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16781,6 +26429,12 @@
     "sane": "varela_round",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "hebrew",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16793,6 +26447,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16801,6 +26460,9 @@
     "sane": "vast_shadow",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16817,6 +26479,11 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16828,6 +26495,11 @@
       "0,500",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16836,6 +26508,13 @@
     "sane": "viaoda_libre",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16844,6 +26523,10 @@
     "sane": "vibes",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "arabic",
+      "latin"
     ]
   },
   {
@@ -16852,6 +26535,9 @@
     "sane": "vibur",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16873,6 +26559,14 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16881,6 +26575,9 @@
     "sane": "vidaloka",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16889,6 +26586,10 @@
     "sane": "viga",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16897,6 +26598,11 @@
     "sane": "vina_sans",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16905,6 +26611,10 @@
     "sane": "voces",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16916,6 +26626,9 @@
       "1,400",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16935,6 +26648,14 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16946,6 +26667,13 @@
       "0,600",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16954,6 +26682,11 @@
     "sane": "voltaire",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16962,6 +26695,11 @@
     "sane": "vt323",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16970,6 +26708,11 @@
     "sane": "vujahday_script",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -16978,6 +26721,10 @@
     "sane": "waiting_for_the_sunrise",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -16986,6 +26733,9 @@
     "sane": "wallpoet",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -16994,6 +26744,9 @@
     "sane": "walter_turncoat",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -17002,6 +26755,10 @@
     "sane": "warnes",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17010,6 +26767,11 @@
     "sane": "water_brush",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17018,6 +26780,11 @@
     "sane": "waterfall",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17034,6 +26801,9 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "latin"
     ]
   },
   {
@@ -17042,6 +26812,10 @@
     "sane": "wellfleet",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17050,6 +26824,10 @@
     "sane": "wendy_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17058,6 +26836,11 @@
     "sane": "whisper",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17067,6 +26850,11 @@
     "variants": [
       "0,400",
       "0,500"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17075,6 +26863,32 @@
     "sane": "wire_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin"
+    ]
+  },
+  {
+    "category": "serif",
+    "name": "Wittgenstein",
+    "sane": "wittgenstein",
+    "variants": [
+      "0,400",
+      "0,500",
+      "0,600",
+      "0,700",
+      "0,800",
+      "0,900",
+      "1,400",
+      "1,500",
+      "1,600",
+      "1,700",
+      "1,800",
+      "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17087,6 +26901,13 @@
       "0,600",
       "0,700",
       "0,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17104,6 +26925,13 @@
       "1,700",
       "0,800",
       "1,800"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17129,6 +26957,11 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17137,6 +26970,11 @@
     "sane": "workbench",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -17146,6 +26984,11 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17159,6 +27002,11 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "sinhala"
     ]
   },
   {
@@ -17172,6 +27020,15 @@
       "0,500",
       "0,600",
       "0,700"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -17185,6 +27042,11 @@
       "0,500",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17193,6 +27055,11 @@
     "sane": "yarndings_12",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -17201,6 +27068,11 @@
     "sane": "yarndings_12_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -17209,6 +27081,11 @@
     "sane": "yarndings_20",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -17217,6 +27094,11 @@
     "sane": "yarndings_20_charted",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "math",
+      "symbols"
     ]
   },
   {
@@ -17225,6 +27107,11 @@
     "sane": "yatra_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "devanagari",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17233,6 +27120,10 @@
     "sane": "yellowtail",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17241,6 +27132,10 @@
     "sane": "yeon_sung",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "korean",
+      "latin"
     ]
   },
   {
@@ -17249,6 +27144,13 @@
     "sane": "yeseva_one",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17257,6 +27159,10 @@
     "sane": "yesteryear",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17265,6 +27171,13 @@
     "sane": "yomogi",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17273,6 +27186,10 @@
     "sane": "young_serif",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17290,6 +27207,11 @@
       "1,500",
       "1,600",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext",
+      "vietnamese"
     ]
   },
   {
@@ -17315,6 +27237,16 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -17340,6 +27272,16 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -17365,6 +27307,16 @@
       "1,700",
       "1,800",
       "1,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -17381,6 +27333,16 @@
       "0,700",
       "0,800",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "latin-ext",
+      "math",
+      "symbols",
+      "vietnamese"
     ]
   },
   {
@@ -17389,6 +27351,12 @@
     "sane": "yuji_boku",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17397,6 +27365,11 @@
     "sane": "yuji_hentaigana_akari",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17405,6 +27378,11 @@
     "sane": "yuji_hentaigana_akebono",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17413,6 +27391,12 @@
     "sane": "yuji_mai",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17421,6 +27405,12 @@
     "sane": "yuji_syuku",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17429,6 +27419,30 @@
     "sane": "yusei_magic",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "japanese",
+      "latin",
+      "latin-ext"
+    ]
+  },
+  {
+    "category": "sans-serif",
+    "name": "Zain",
+    "sane": "zain",
+    "variants": [
+      "0,200",
+      "0,300",
+      "1,300",
+      "0,400",
+      "1,400",
+      "0,700",
+      "0,800",
+      "0,900"
+    ],
+    "subsets": [
+      "arabic",
+      "latin"
     ]
   },
   {
@@ -17437,6 +27451,10 @@
     "sane": "zcool_kuaile",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -17445,6 +27463,10 @@
     "sane": "zcool_qingke_huangyou",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -17453,6 +27475,10 @@
     "sane": "zcool_xiaowei",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -17461,6 +27487,13 @@
     "sane": "zen_antique",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17469,6 +27502,13 @@
     "sane": "zen_antique_soft",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17477,6 +27517,10 @@
     "sane": "zen_dots",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17489,6 +27533,12 @@
       "0,500",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17501,6 +27551,12 @@
       "0,500",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17509,6 +27565,13 @@
     "sane": "zen_kurenaido",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17518,6 +27581,10 @@
     "variants": [
       "0,400",
       "1,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17530,6 +27597,13 @@
       "0,500",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17542,6 +27616,13 @@
       "0,600",
       "0,700",
       "0,900"
+    ],
+    "subsets": [
+      "cyrillic",
+      "greek",
+      "japanese",
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17550,6 +27631,10 @@
     "sane": "zen_tokyo_zoo",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17558,6 +27643,10 @@
     "sane": "zeyada",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17566,6 +27655,10 @@
     "sane": "zhi_mang_xing",
     "variants": [
       "0,400"
+    ],
+    "subsets": [
+      "chinese-simplified",
+      "latin"
     ]
   },
   {
@@ -17583,6 +27676,10 @@
       "1,600",
       "0,700",
       "1,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   },
   {
@@ -17592,6 +27689,10 @@
     "variants": [
       "0,400",
       "0,700"
+    ],
+    "subsets": [
+      "latin",
+      "latin-ext"
     ]
   }
 ]

--- a/packages/fontpicker/scripts/buildFontPreviews.ts
+++ b/packages/fontpicker/scripts/buildFontPreviews.ts
@@ -51,6 +51,7 @@ interface FontPreviewInfo {
   name: string
   sane: string
   variants: string[]
+  subsets?: string[]
 }
 
 interface DownloadedFont {
@@ -59,6 +60,7 @@ interface DownloadedFont {
   localFile: string
   localFileSvg: string
   variants: string[]
+  subsets?: string[]
   sanename?: string
   top?: number
 }
@@ -114,6 +116,7 @@ class GoogleFonts {
         localFile: localFile,
         localFileSvg: localFileSvg,
         variants: this.shortVariants(info),
+        subsets: info['subsets'],
       }
       fonts.push(font)
     }
@@ -252,6 +255,7 @@ class FontPreviewBuilder {
         name: font['name'],
         sane: font['sanename'] ?? sanify(font.name),
         variants: font['variants'],
+        subsets: font['subsets'],
       }
       json.push(j)
     }

--- a/packages/fontpicker/src/components/FontPicker.tsx
+++ b/packages/fontpicker/src/components/FontPicker.tsx
@@ -11,7 +11,7 @@ export interface FontPickerProps extends React.ComponentPropsWithoutRef<'div'> {
   loaderOnly?: boolean
   loadAllVariants?: boolean
   loadFonts?: string[] | FontToVariant[] | string
-  googleFonts?: string[] | Font[] | string
+  googleFonts?: string[] | Font[] | string | ((font: Font) => boolean)
   fontCategories?: string[] | string
   localFonts?: Font[] | undefined
 
@@ -37,6 +37,7 @@ export interface Font {
   cased: string
   variants: Variant[]
   isLocal?: boolean
+  subsets?: string[]
 }
 
 export interface FourFonts {
@@ -221,7 +222,7 @@ export default function FontPicker({
         .split(',')
         .map((v) => v.toLowerCase())
       activeFonts = [...allGoogleFonts.filter((a: Font) => fontNames.includes(a.cased))]
-    } else {
+    } else if (Array.isArray(googleFonts)) {
       const fontNames = googleFonts.map((v) => {
         if (typeof v === 'string') {
           return v.toLowerCase()
@@ -230,6 +231,8 @@ export default function FontPicker({
         }
       })
       activeFonts = [...allGoogleFonts.filter((a: Font) => fontNames.includes(a.cased))]
+    } else if (typeof googleFonts === 'function') {
+      activeFonts = [...allGoogleFonts.filter(googleFonts)]
     }
     localFonts.forEach((font: Font) => {
       activeFonts.push({


### PR DESCRIPTION
https://github.com/ae9is/react-fontpicker/issues/73

- added "subsets" info fontInfo.json
- googleFonts accept filter function, example:
googleFonts={(font) => !!font.subsets?.includes('chinese-simplified')}