### PR TITLE
80 Sane default font

### DIFF
--- a/packages/fontpicker/cypress/e2e/app.cy.ts
+++ b/packages/fontpicker/cypress/e2e/app.cy.ts
@@ -110,6 +110,11 @@ describe('react fontpicker docs', () => {
     cy.get('@picker').find('.fontpicker__option .font-preview-zcool_kuaile').should('have.length', 1)
   })
 
+  it('falls back to sane default font with googleFonts filter applied', () => {
+    cy.getBySel('filterlanguage-fontpicker').as('picker')
+    cy.get('@picker').find('.fontpicker__preview .font-preview-open-sans').should('have.length', 0)
+  })
+
   it('can select fonts in list box mode', () => {
     cy.getBySel('listbox-fontpicker').as('picker')
     cy.getBySel('listbox-value').as('value')

--- a/packages/fontpicker/src/components/FontPicker.tsx
+++ b/packages/fontpicker/src/components/FontPicker.tsx
@@ -109,8 +109,6 @@ export default function FontPicker({
   ...rest
 }: FontPickerProps) {
   const [focused, setFocused] = useState(false)
-  const [typedSearch, setTypedSearch] = useState(defaultValue)
-  const [searchContent, setSearchContent] = useState(defaultValue)
   const [selectedFontIndex, setSelectedFontIndex] = useState(-1)
   const [currentFontIndex, setCurrentFontIndex] = useState(-1)
   const [prevLoadFonts, setPrevLoadFonts] = useState<string[]>([])
@@ -266,6 +264,21 @@ export default function FontPicker({
     }
     return [...activeFontsInCategory]
   }, [googleFonts, allGoogleFonts, localFonts, fontCategories])
+
+  // Corrected from default font ("Open Sans") if default doesn't exist in currently allowed (filtered) fonts
+  const saneDefaultValue = useMemo(() => {
+    const search = defaultValue.toLowerCase().trim()
+    if (!fonts || fonts?.length <= 0) {
+      return defaultValue
+    }
+    if (fonts.some((a) => a.cased === search)) {
+      return defaultValue
+    }
+    return fonts[0].name
+  }, [fonts, defaultValue])
+
+  const [typedSearch, setTypedSearch] = useState(saneDefaultValue)
+  const [searchContent, setSearchContent] = useState(saneDefaultValue)
 
   const matchingFonts = useMemo(() => {
     const search = typedSearch.toLowerCase().trim()
@@ -604,7 +617,7 @@ export default function FontPicker({
     return fourVariants
   }
 
-  const defaultCurrent = getFontByName(defaultValue) || defaultFont
+  const defaultCurrent = getFontByName(saneDefaultValue) || defaultFont
   const [current, setCurrentState] = useState<Font>(defaultCurrent)
 
   handleLoadFont()


### PR DESCRIPTION
If the default font prop `defaultValue` (which is "Open Sans" if not otherwise set) does not exist in currently filtered fonts, then fall back to the first font in the list.

Previously when using the googleFonts filter there could be the situation where defaultValue was not specified and thus "Open Sans", but "Open Sans" was not an allowed font in the list.

Fixes #80 