### PR TITLE
78 support light theme

### DIFF
--- a/packages/fontpicker/src/components/FontPicker.css
+++ b/packages/fontpicker/src/components/FontPicker.css
@@ -24,6 +24,9 @@
   font-size: 16px;
   background-color: #555;
   color: #fff;
+  outline: none !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
 }
 .fontpicker__search:focus {
   cursor: text;


### PR DESCRIPTION
Closes #78 

Adds a theme for light mode to the default font picker CSS file.

Also adds a small fix to prevent rounded font search input borders, which particularly clash with the picker styling in light mode.