### PR TITLE
Fix readme badge styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # react-fontpicker
 
 <p>
-  <a href="https://www.npmjs.com/package/react-fontpicker-ts" title="react-fontpicker-ts npm package version">
-    <img src="https://img.shields.io/npm/v/react-fontpicker-ts.svg?label=npm/fontpicker" />
+  <a href="https://www.npmjs.com/package/react-fontpicker-ts" title="react-fontpicker-ts npm package version" style="text-decoration: none">
+    <img src="https://img.shields.io/npm/v/react-fontpicker-ts.svg?label=npm/fontpicker" alt="Fontpicker" />
   </a>
-  <a href="https://www.npmjs.com/package/react-fontpicker-ts-lite" title="react-fontpicker-ts-lite npm package version">
-    <img src="https://img.shields.io/npm/v/react-fontpicker-ts-lite.svg?label=npm/fontpicker-lite" />
+  &nbsp;
+  <a href="https://www.npmjs.com/package/react-fontpicker-ts-lite" title="react-fontpicker-ts-lite npm package version" style="text-decoration: none">
+    <img src="https://img.shields.io/npm/v/react-fontpicker-ts-lite.svg?label=npm/fontpicker-lite" alt="Fontpicker-Lite" />
   </a>
 </p>
 


### PR DESCRIPTION
When deployed to GitHub, the styling for the first README badge ended up displaying a small amount of underline (from the badge link <a />).

This fixes that, and also adds a little space between the badges and alt text for the images.