### PR TITLE
Fix upgrade packages script

### DIFF
--- a/.github/workflows/upgradebot.yml
+++ b/.github/workflows/upgradebot.yml
@@ -1,6 +1,8 @@
 # Upgrade packages using npm-check-updates, test, and create a PR if successful.
 # Add an upgrade-packages script in your package.json, for ex:
-#  "upgrade-packages": "ncu -u"
+#  "upgrade-packages": "ncu -u -c 7"
+# Note: --cooldown 7d means ignore package versions newer than 7 days ago, 
+#  should match npm setting `min-release-age=7` in .npmrc
 
 name: upgradebot
 

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "upgrade-packages": "ncu -u"
+    "upgrade-packages": "ncu -u -c 7"
   },
   "dependencies": {
     "eslint": "9.39.4",

--- a/packages/fontpicker/package.json
+++ b/packages/fontpicker/package.json
@@ -66,7 +66,7 @@
     "svg-text-test": "tsc -p tsconfig.scripts.json && node ./scripts/getTextSvg.js",
     "preview": "vite preview --host 0.0.0.0 --outDir docs",
     "upgrade": "npm run upgrade-packages && npm install && npm run build && npm run test",
-    "upgrade-packages": "ncu -u"
+    "upgrade-packages": "ncu -u -c 7"
   },
   "tsup": {
     "entry": [

--- a/test/pack-test/package.json
+++ b/test/pack-test/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write src",
     "lint": "eslint src",
     "prep": "bash prep-pack-test.sh",
-    "upgrade-packages": "ncu -u"
+    "upgrade-packages": "ncu -u -c 7"
   },
   "dependencies": {
     "@vitejs/plugin-react-swc": "4.3.0",


### PR DESCRIPTION
Add cooldown to npm-check-updates script matching `.npmrc`. Without this almost always there will be a dependency that is too new and the upgrade packages workflow will fail.